### PR TITLE
Clarify dual scanning modes: local (default) and GitHub CLI (optional)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,9 @@ The tool scans repositories for files like `CLAUDE.md`, `.cursorrules`, `.github
 - Cross-reference detection between AI instruction files
 - Content quality evaluation (sections, commands, constraints)
 - Multiple output formats (terminal, JSON, markdown, CSV)
-- GitHub CLI integration for scanning repos without cloning (--github-repo, --github-org)
+- **Dual scanning modes**: Local scanning (default) OR GitHub CLI (optional, no cloning!)
+  - Local: Scan repositories on disk
+  - GitHub CLI: Scan remote repos without cloning (--github-repo, --github-org)
 
 ## Architecture
 
@@ -69,9 +71,58 @@ pytest tests/ -v
 - Adjust scoring thresholds: Edit `_calculate_overall_level` in `scanner.py`
 - Add new cross-reference patterns: Edit `CROSS_REF_PATTERNS` in `scanner.py`
 - Add new quality indicators: Edit `QUALITY_PATTERNS` in `scanner.py`
-- Scan GitHub repos without cloning: Use `measure-ai-proficiency --github-repo owner/repo` or `--github-org org-name`
-- Discover repos in GitHub org: Run `scripts/find-org-repos.sh <org-name>` to find active repos with AI artifacts (or just use `--github-org` to scan directly)
-- Improve repo AI context: Use the **AI Context Improvement Agent** in `.claude/agents/improve-ai-context.agent.md` to systematically create/improve context files
+
+## Scanning Options
+
+The tool supports **two scanning modes** - use whichever fits your workflow:
+
+### Local Scanning (Default)
+Scan repositories on disk. Works offline, no authentication needed.
+
+```bash
+# Scan current directory
+measure-ai-proficiency
+
+# Scan specific repository
+measure-ai-proficiency /path/to/repo
+
+# Scan multiple repositories
+measure-ai-proficiency repo1 repo2 repo3
+
+# Scan all repos in a directory (cloned org)
+measure-ai-proficiency --org /path/to/org-repos
+```
+
+### GitHub CLI Scanning (Optional)
+Scan GitHub repositories without cloning. Requires `gh` CLI and authentication.
+
+```bash
+# Scan single GitHub repo
+measure-ai-proficiency --github-repo owner/repo
+
+# Scan entire GitHub org
+measure-ai-proficiency --github-org org-name
+
+# Limit number of repos
+measure-ai-proficiency --github-org org-name --limit 50
+
+# Combine with output formats
+measure-ai-proficiency --github-org org --format json --output report.json
+```
+
+**Why use GitHub CLI mode?**
+- No need to clone repositories (saves disk space)
+- Faster for large organizations (only downloads relevant files)
+- Works with private repos (if authenticated)
+- Discover repos in GitHub org: Run `scripts/find-org-repos.sh <org-name>` to find active repos with AI artifacts
+
+**Both modes support:**
+- All output formats (terminal, JSON, markdown, CSV)
+- All CLI flags (--format, --output, -q, --min-level)
+- Cross-reference detection and quality scoring
+
+### Improving Repository AI Context
+Use the **AI Context Improvement Agent** in `.claude/agents/improve-ai-context.agent.md` to systematically create/improve context files. Works with both scanning modes.
 
 ## Cross-Reference Detection
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,11 @@ pip install -e .
 
 ## Usage
 
-### Basic Commands
+The tool supports **two scanning modes** - choose the one that fits your workflow:
+
+### Mode 1: Local Scanning (Default)
+
+Scan repositories on your local disk. Works offline, no authentication needed.
 
 ```bash
 # Scan current directory
@@ -78,13 +82,19 @@ measure-ai-proficiency /path/to/repo
 # Scan multiple repositories
 measure-ai-proficiency /path/to/repo1 /path/to/repo2
 
-# Scan all repos in a directory (GitHub org)
+# Scan all repos in a directory (cloned GitHub org)
 measure-ai-proficiency --org /path/to/cloned-org
 ```
 
-### GitHub Integration (No Cloning Required!)
+**Best for:**
+- Local development
+- Offline scanning
+- Repos already on disk
+- No GitHub authentication needed
 
-Scan GitHub repositories directly without cloning them using the GitHub CLI:
+### Mode 2: GitHub CLI Scanning (Optional)
+
+Scan GitHub repositories directly **without cloning** them using the GitHub CLI:
 
 ```bash
 # Scan a single GitHub repository
@@ -100,6 +110,12 @@ measure-ai-proficiency --github-org anthropic --limit 50
 measure-ai-proficiency --github-org your-org --format json --output report.json
 ```
 
+**Best for:**
+- Scanning organizations without cloning
+- Large-scale analysis
+- Private repos (with authentication)
+- Quick assessments of remote repos
+
 **Requirements:**
 - [GitHub CLI (gh)](https://cli.github.com/) must be installed
 - Must be authenticated: `gh auth login`
@@ -110,9 +126,34 @@ measure-ai-proficiency --github-org your-org --format json --output report.json
 3. Scans the files locally in a temporary directory
 4. Cleans up automatically after scanning
 
-This is much faster than cloning hundreds of repositories and requires no disk space for the repositories themselves.
+**Advantages over cloning:**
+- ✅ Much faster (only downloads relevant files)
+- ✅ No disk space needed for full repositories
+- ✅ Works with hundreds of repos efficiently
+- ✅ Automatic cleanup after scanning
+
+### Choosing Between Modes
+
+| Feature | Local Scanning | GitHub CLI Scanning |
+|---------|----------------|---------------------|
+| **Setup** | None | Requires `gh` CLI + auth |
+| **Network** | Works offline | Requires internet |
+| **Speed** | Fast for local repos | Fast for remote repos |
+| **Disk Space** | Uses existing repos | Minimal (temp files only) |
+| **Authentication** | Not needed | GitHub auth required |
+| **Private Repos** | Must clone first | Works if authenticated |
+| **Best Use** | Local development | Organization-wide analysis |
+
+**Note:** Both scanning modes support all features:
+- All output formats (terminal, JSON, markdown, CSV)
+- All CLI flags (--format, --output, -q, --min-level)
+- Cross-reference detection and quality scoring
+- Tool auto-detection
+- Custom configuration (`.ai-proficiency.yaml`)
 
 ### Output Formats
+
+Both scanning modes work with all output formats:
 
 ```bash
 # Terminal output (default, with colors)

--- a/measure_ai_proficiency/__main__.py
+++ b/measure_ai_proficiency/__main__.py
@@ -50,13 +50,23 @@ def main():
         description="Measure AI coding proficiency based on context engineering artifacts.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
+Scanning Methods:
+  LOCAL (default):         Scan local repositories on disk
+  GITHUB CLI (optional):   Scan GitHub repos without cloning (requires gh CLI)
+
 Examples:
+  # Local scanning (default)
   %(prog)s                           Scan current directory
   %(prog)s /path/to/repo             Scan specific repository
   %(prog)s repo1 repo2 repo3         Scan multiple repositories
   %(prog)s --org /path/to/org        Scan all repos in directory
+
+  # GitHub CLI scanning (optional, no cloning!)
   %(prog)s --github-repo owner/repo  Scan GitHub repo without cloning
   %(prog)s --github-org anthropic    Scan all repos in GitHub org
+  %(prog)s --github-org org --limit 50  Limit number of repos
+
+  # Output formats (work with both methods)
   %(prog)s --format json             Output as JSON
   %(prog)s --format markdown -o report.md  Save markdown report
   %(prog)s -q                        Quiet mode (hide file details)
@@ -70,6 +80,10 @@ Maturity Levels (aligned with Steve Yegge's 8-stage model):
   Level 6: Fleet infrastructure (Beads, shared context, workflows)
   Level 7: Agent fleet (governance, scheduling, pipelines)
   Level 8: Custom orchestration (Gas Town, meta-automation, frontier)
+
+GitHub CLI Requirements:
+  Install: https://cli.github.com/
+  Authenticate: gh auth login
         """,
     )
 


### PR DESCRIPTION
Updated documentation to make it clearer that both local and GitHub CLI
scanning are available as separate options:

- Local scanning (default): Scan repositories on disk, works offline
- GitHub CLI scanning (optional): Scan remote repos without cloning

Changes:
- __main__.py: Updated CLI help text to clearly separate the two modes
- CLAUDE.md: Added "Scanning Options" section with detailed comparison
- README.md: Added "Choosing Between Modes" comparison table

Both modes support all features (output formats, cross-references, etc.)
Skills and agents already documented both modes, no changes needed there.

This makes it clear that GitHub CLI integration is an additional feature,
not a replacement for the original local scanning functionality.