### PR TITLE
Update factory docs across CLAUDE.md, AGENTS.md, and AGENT_FACTORY.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,13 @@ After updating documentation, update skills:
 
 ## Agent Factory: Shared Context
 
-The sections below are read by every agentic workflow in the factory chain (`spec-refiner`, `reviewer`, `self-improvement-meta`).
+The sections below are read by every agentic workflow in the factory chain. The factory consists of 10 workflows organized in three tiers:
+
+**Factory chain** (custom, skill-backed): `spec-refiner`, `reviewer`, `self-improvement-meta`, `ci-cleaner`, `contribution-checker`
+**Support workflows** (from githubnext/agentics): `issue-triage`, `plan`, `pr-fix`
+**Project-specific**: `ai-proficiency-pr-review`, `ai-proficiency-weekly-report`
+
+See `docs/AGENT_FACTORY.md` for the full guide with step-by-step usage instructions, label reference, and debugging commands.
 
 ### Core principles
 
@@ -256,7 +262,25 @@ The routing rules above are about the **implementer step** (who writes the code 
 
 - GitHub toolset (read-only by default, write via safe-outputs only)
 - `cache-memory` and `repo-memory` for cross-run state
+- `bash: true` for shell commands (ci-cleaner, pr-fix)
+- `edit:` for file modifications (ci-cleaner, pr-fix)
+- `web-fetch:` for external content (issue-triage, pr-fix)
 - DX Data Cloud MCP server (configured per workflow that needs it, optional for PoC). Reviewer agents should use this for context when available.
+
+### Workflow inventory
+
+| Workflow | Trigger | Safe outputs | Skill |
+|----------|---------|-------------|-------|
+| `spec-refiner` | Issue labeled `needs-spec` | update-issue, add-comment, create-pull-request, add-labels, remove-labels | plan-interview |
+| `reviewer` | PR opened / updated | add-comment, add-labels | dx-data-navigator, intent-framed-agent |
+| `self-improvement-meta` | Nightly (~2am) | create-pull-request, create-issue | self-improvement |
+| `ci-cleaner` | CI failure on main | create-pull-request | (none, uses bash/edit directly) |
+| `contribution-checker` | PR opened / updated | add-comment | (none, reads CONTRIBUTING.md) |
+| `issue-triage` | Issue opened / reopened | add-labels, add-comment | (none, githubnext/agentics) |
+| `plan` | `/plan` slash command | create-issue | (none, githubnext/agentics) |
+| `pr-fix` | `/pr-fix` slash command | push-to-pull-request-branch, add-comment, create-issue | (none, githubnext/agentics) |
+| `ai-proficiency-pr-review` | PR opened / `/assess-proficiency` | add-comment | measure-ai-proficiency |
+| `ai-proficiency-weekly-report` | Weekly (Monday 9am) | create-issue | measure-ai-proficiency |
 
 ### Human circuit breaker
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,28 @@ The project now includes an **MCP (Model Context Protocol) server** that makes A
 
 See `docs/MCP.md` for full documentation, examples, and troubleshooting.
 
+## Agent Factory
+
+This repo runs a 10-workflow agent factory via [GitHub Agentic Workflows (gh-aw)](https://github.github.com/gh-aw/). The chain flows: triage, spec, plan, implement, review, fix, learn.
+
+**Workflows** live in `.github/workflows/*.md` and compile to `.lock.yml` files via `gh aw compile`.
+
+**Key files:**
+- `docs/AGENT_FACTORY.md` - Full usage guide with step-by-step instructions
+- `docs/chain.md` - Architecture diagram and design rationale
+- `AGENTS.md` - Shared context read by every workflow at run start
+
+**Common tasks:**
+- Add a new workflow: create `.github/workflows/<name>.md`, run `gh aw compile <name>`
+- Edit a workflow: modify the `.md` file, run `gh aw compile <name>`, commit both `.md` and `.lock.yml`
+- Update gh-aw: `gh extension upgrade gh-aw`, then `gh aw compile` to recompile all lock files
+- Add a skill for workflows: create `.claude/skills/<name>/SKILL.md`, reference it from the workflow body
+- Debug a run: `gh aw logs <workflow>` or `gh aw audit <run-id>`
+
+**Factory chain:** issue-triage > spec-refiner > /plan > implementer > reviewer + contribution-checker > /pr-fix > ci-cleaner > self-improvement-meta (nightly)
+
+**Human decisions:** (1) approve the plan PR, (2) assign the implementer, (3) merge the final PR, (4) approve learnings. Everything else is automated.
+
 ## Architecture
 
 ```
@@ -137,6 +159,19 @@ measure_ai_proficiency/
 scripts/
 ├── find-org-repos.sh  # GitHub org discovery script (uses gh CLI)
 └── README.md          # Script documentation
+
+.github/workflows/     # Agentic workflows (gh-aw)
+├── spec-refiner.md              # Plan file from issue context
+├── reviewer.md                  # Plan-aware PR review
+├── self-improvement-meta.md     # Nightly learnings extraction
+├── ci-cleaner.md                # Auto-fix CI on main
+├── contribution-checker.md      # CONTRIBUTING.md compliance
+├── issue-triage.md              # Auto-label issues (githubnext/agentics)
+├── plan.md                      # /plan slash command (githubnext/agentics)
+├── pr-fix.md                    # /pr-fix slash command (githubnext/agentics)
+├── ai-proficiency-pr-review.md  # Proficiency score per PR
+├── ai-proficiency-weekly-report.md  # Weekly proficiency trends
+└── *.lock.yml                   # Compiled GitHub Actions YAML
 ```
 
 ## Key Abstractions

--- a/docs/AGENT_FACTORY.md
+++ b/docs/AGENT_FACTORY.md
@@ -1,29 +1,44 @@
 # Agent Factory: End-to-End Agentic Workflows
 
-A complete **spec, plan, implement, review, learn** agent factory powered by [GitHub Agentic Workflows (gh-aw)](https://github.github.com/gh-aw/). Five specialist agents chain together through GitHub events (labels, PRs, comments). No orchestrator, no DAG. Each agent does one job, hands off via a label swap, and the next agent picks it up.
+A complete **triage, spec, plan, implement, review, fix, learn** agent factory powered by [GitHub Agentic Workflows (gh-aw)](https://github.github.com/gh-aw/). Ten workflows chain together through GitHub events (labels, PRs, comments). No orchestrator, no DAG. Each agent does one job, hands off via a label swap, and the next agent picks it up. This is choreography, not orchestration.
 
-## How the Chain Works
+## The Complete Chain
 
 ```
-1. Open issue, add label "needs-spec"
-       |
-       v
-2. spec-refiner writes a plan file, recommends an implementer
-       |
-       v
-3. /plan breaks the plan into sub-issues
-       |
-       v
-4. Human assigns sub-issues to Claude / Copilot / Codex
-       |
-       v
-5. reviewer checks the PR against the plan
-       |
-       v
-6. self-improvement-meta (nightly) turns failures into guardrails
+issue opened
+  |
+  v
+issue-triage (auto-labels by type, detects spam)
+  |
+  v
+human adds "needs-spec" label
+  |
+  v
+spec-refiner (structured plan file + implementer recommendation)
+  |
+  v
+/plan (breaks plan into sub-issues)
+  |
+  v
+human assigns sub-issues to Claude / Copilot / Codex
+  |
+  v
+PR opened
+  |
+  +---> reviewer (plan-aware code review with implementer calibration)
+  +---> contribution-checker (CONTRIBUTING.md compliance)
+  |
+  v
+needs-changes? ---> /pr-fix (auto-fix CI failures)
+  |
+  v
+CI failure on main? ---> ci-cleaner (lint, test, compile fix loop)
+  |
+  v
+nightly ---> self-improvement-meta (extract learnings, commit guardrails)
 ```
 
-State between phases lives in GitHub, not in memory. Each agent starts cold. The spec gets written back to the issue body so the planner can read it. The plan sub-issues get labeled so the implementer can find them. The reviewer reads the plan file from disk. Every handoff is mediated by a file, a label, or a PR.
+State lives in GitHub, not in memory. Each agent starts cold. Every handoff is mediated by a file, a label, or a PR. This makes the chain debuggable: you can inspect the state at any point by looking at the repo.
 
 ## Prerequisites
 
@@ -39,27 +54,28 @@ State between phases lives in GitHub, not in memory. Each agent starts cold. The
 
 Create a new issue describing a feature, bug fix, or refactor. Keep it concrete: what should change, why, and any constraints you know about.
 
-Add the `needs-spec` label.
+The `issue-triage` workflow fires automatically on new issues. It reads the content, selects appropriate labels (bug, enhancement, question, documentation), detects spam, and posts analysis notes with debugging strategies and context from similar issues.
 
-### Step 2: Watch spec-refiner Work
+### Step 2: Label for Spec Refinement
 
-The `spec-refiner` workflow triggers automatically. It reads the issue, runs the `plan-interview` skill against the issue context, and produces:
+After triage, add the `needs-spec` label to start the factory chain.
 
+The `spec-refiner` workflow triggers. It reads the issue, runs the `plan-interview` skill, and produces:
 - A plan file at `docs/plans/plan-NNN-<slug>.md` (opened as a PR)
 - A recommended implementer (Claude Opus 4.6, Claude Sonnet 4.6, Copilot, or Codex)
 - A label swap: `needs-spec` removed, `needs-plan` added
 
-If the agent cannot answer something from context alone, it marks the gap with **NEEDS HUMAN INPUT** and adds the `blocked-on-human` label instead. Add a comment with the missing context, remove the label, and re-trigger.
+If the agent cannot answer something from context alone, it marks the gap with **NEEDS HUMAN INPUT** and adds the `blocked-on-human` label. Add a comment with the missing context, remove the label, and re-trigger.
 
 ### Step 3: Review and Approve the Plan
 
 Read the plan PR. Check the success criteria, the implementation checklist, and the recommended implementer. If it looks right, merge it.
 
-The `needs-plan` label triggers the `/plan` workflow (from [githubnext/agentics](https://github.com/githubnext/agentics)), which breaks the plan into sub-issues labeled `ready-for-implementation`.
+The `needs-plan` label triggers the `/plan` workflow, which breaks the plan into sub-issues labeled `ready-for-implementation`.
 
 ### Step 4: Assign an Implementer
 
-Open each sub-issue on github.com. Go to the Agents tab and assign it to the recommended agent. The spec-refiner wrote a recommendation in the plan file based on complexity:
+Open each sub-issue on github.com. Go to the Agents tab and assign it to the recommended agent:
 
 | Implementer | When to use |
 |-------------|-------------|
@@ -72,20 +88,27 @@ The agent opens a PR with its implementation.
 
 ### Step 5: Automated Review
 
-The `reviewer` workflow triggers on the new PR. It:
+Two workflows trigger on the new PR:
 
-1. **Finds the plan file** and checks every success criterion: Met, Partial, Missed, or Drifted
-2. **Detects the implementer** from the PR author and applies calibration:
+**Reviewer** checks the PR against the plan file:
+1. Finds the plan and checks every success criterion: Met, Partial, Missed, or Drifted
+2. Detects the implementer and applies calibration:
    - Claude PRs: checked for scope drift (tends to over-implement)
    - Copilot PRs: checked for test coverage gaps (tends to under-test)
    - Codex PRs: checked for correctness on unusual control flow
    - Human PRs: standard rigor
-3. **Pulls team baseline** from DX Data Cloud (if configured) for context
-4. **Posts a structured review comment** with a verdict: `ai-reviewed`, `needs-changes`, or `fast-track`
+3. Pulls team baseline from DX Data Cloud (if configured) for context
+4. Posts a structured review comment with a verdict: `ai-reviewed`, `needs-changes`, or `fast-track`
 
-If the verdict is `needs-changes`, the `/pr-fix` workflow can auto-fix CI failures. Otherwise, a human does the final review and merges.
+**Contribution checker** evaluates the PR against `docs/CONTRIBUTING.md`: on-topic, focused, has tests, has description, skills synced.
 
-### Step 6: The Outer Loop (Nightly)
+### Step 6: Fix Loop
+
+If the reviewer labels the PR `needs-changes`, comment `/pr-fix` to trigger the automated fix workflow. It analyzes failing CI checks, identifies root causes from error logs, implements fixes, and pushes corrections to the PR branch.
+
+If CI fails on `main` after a merge, the `ci-cleaner` workflow triggers automatically. It runs `ruff check --fix`, `pytest`, and `gh aw compile` in sequence, then opens a PR with the fixes. It includes a mandatory exit protocol (always produces a PR or noop) and a file-count guard (refuses to create PRs with 50+ changed files).
+
+### Step 7: The Outer Loop (Nightly)
 
 `self-improvement-meta` runs every night around 2am. It:
 
@@ -94,9 +117,7 @@ If the verdict is `needs-changes`, the `/pr-fix` workflow can auto-fix CI failur
 3. Deduplicates against existing entries in `.learnings/LEARNINGS.md`
 4. Opens a PR that adds prevention rules to `AGENTS.md` or the relevant workflow file
 
-When you merge that PR, the next run of the affected agent reads the updated instructions. The factory gets smarter every day.
-
-If there are no failures, it calls noop. Silence is the correct signal when the factory is healthy.
+When you merge that PR, the next run of the affected agent reads the updated instructions. The factory gets smarter every day. If there are no failures, it calls noop. Silence is the correct signal when the factory is healthy.
 
 ## Controlling the Chain
 
@@ -106,41 +127,59 @@ If there are no failures, it calls noop. Silence is the correct signal when the 
 | **Skip spec-refinement** | Label the issue `needs-plan` directly instead of `needs-spec` |
 | **Skip automated review** | Label the PR `human-review` and review it yourself |
 | **Trigger manually** | Every workflow has `workflow_dispatch` enabled. Run from the Actions tab. |
+| **Fix a failing PR** | Comment `/pr-fix` on the PR |
+| **Break a plan into tasks** | Comment `/plan` on the issue |
 | **Fast-forward simple changes** | For trivial fixes, skip the whole chain: just open a PR directly |
 
-## The Workflows
+## All Workflows
 
-| File | Trigger | Purpose |
-|------|---------|---------|
-| [`spec-refiner.md`](../.github/workflows/spec-refiner.md) | Issue labeled `needs-spec` | Structured plan file from issue context |
-| [`plan.md`](../.github/workflows/plan.md) | `/plan` slash command | Break plan into sub-issues with task labels |
+### Factory Chain (custom, skill-backed)
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| [`spec-refiner.md`](../.github/workflows/spec-refiner.md) | Issue labeled `needs-spec` | Structured plan file from issue context using plan-interview skill |
 | [`reviewer.md`](../.github/workflows/reviewer.md) | PR opened / updated | Plan-aware code review with implementer calibration |
-| [`pr-fix.md`](../.github/workflows/pr-fix.md) | `/pr-fix` slash command | Auto-fix failing CI on PR branches |
 | [`self-improvement-meta.md`](../.github/workflows/self-improvement-meta.md) | Nightly (~2am) | Extract learnings from failures, commit prevention rules |
-| [`issue-triage.md`](../.github/workflows/issue-triage.md) | Issue opened / reopened | Label, categorize, and provide analysis notes |
 | [`ci-cleaner.md`](../.github/workflows/ci-cleaner.md) | CI failure on main | Auto-fix lint, test, and compilation issues |
 | [`contribution-checker.md`](../.github/workflows/contribution-checker.md) | PR opened / updated | Evaluate PR against CONTRIBUTING.md guidelines |
 
-The factory workflows (`spec-refiner`, `reviewer`, `self-improvement-meta`) are thin adapter shells. The actual agent logic lives in skills. The support workflows (`plan`, `pr-fix`, `issue-triage`) come from the [githubnext/agentics](https://github.com/githubnext/agentics) sample pack.
+These are thin adapter shells. The actual agent logic lives in skills in `.claude/skills/`.
+
+### Support Workflows (from githubnext/agentics)
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| [`issue-triage.md`](../.github/workflows/issue-triage.md) | Issue opened / reopened | Label, categorize, detect spam, provide analysis notes |
+| [`plan.md`](../.github/workflows/plan.md) | `/plan` slash command | Break plan into sub-issues labeled `ready-for-implementation` |
+| [`pr-fix.md`](../.github/workflows/pr-fix.md) | `/pr-fix` slash command | Analyze failing CI, implement fixes, push to PR branch |
+
+Installed via `gh aw add githubnext/agentics/<name>`. These are general-purpose and work out of the box.
+
+### Project-Specific Workflows
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| [`ai-proficiency-pr-review.md`](../.github/workflows/ai-proficiency-pr-review.md) | PR opened / `/assess-proficiency` | AI proficiency score on every PR |
+| [`ai-proficiency-weekly-report.md`](../.github/workflows/ai-proficiency-weekly-report.md) | Weekly (Monday 9am UTC) | Track proficiency trends over time |
 
 ## Skills Used by the Factory
 
 | Skill | Used by | Purpose |
 |-------|---------|---------|
-| [`plan-interview`](../.claude/skills/plan-interview/SKILL.md) | spec-refiner | Structured requirements interview |
-| [`self-improvement`](../.claude/skills/self-improvement/SKILL.md) | self-improvement-meta | Learning capture and promotion |
+| [`plan-interview`](../.claude/skills/plan-interview/SKILL.md) | spec-refiner | Structured requirements interview before planning |
+| [`self-improvement`](../.claude/skills/self-improvement/SKILL.md) | self-improvement-meta | Learning capture, categorization, and promotion |
 | [`dx-data-navigator`](../.claude/skills/dx-data-navigator/SKILL.md) | reviewer | DORA metrics from DX Data Cloud (optional) |
-| [`intent-framed-agent`](../.claude/skills/intent-framed-agent/SKILL.md) | reviewer | Scope drift detection |
+| [`intent-framed-agent`](../.claude/skills/intent-framed-agent/SKILL.md) | reviewer | Scope drift detection against plan intent |
 | [`context-surfing`](../.claude/skills/context-surfing/SKILL.md) | (available) | Context window health monitoring |
 
-Skills live in `.claude/skills/` and work identically in Claude Code, Codex CLI, and gh-aw. Update a skill once, every consumer gets the fix.
+Skills live in `.claude/skills/` and work identically in Claude Code, Codex CLI, and gh-aw. Update a skill once, every consumer gets the fix. The gh-aw workflows read skill files at runtime, not at compile time.
 
 ## Label Reference
 
 | Label | Meaning | Set by |
 |-------|---------|--------|
 | `needs-spec` | Issue needs a structured plan file | Human |
-| `needs-plan` | Spec is ready, waiting for /plan to create sub-issues | spec-refiner |
+| `needs-plan` | Spec is ready, /plan creates sub-issues | spec-refiner |
 | `blocked-on-human` | Agent needs human input before proceeding | spec-refiner |
 | `spec-refined` | Spec refinement is complete | spec-refiner |
 | `ready-for-implementation` | Sub-issue ready for a coding agent | /plan |
@@ -150,36 +189,17 @@ Skills live in `.claude/skills/` and work identically in Claude Code, Codex CLI,
 | `spec-drift` | PR does things the plan did not ask for | reviewer |
 | `human-review` | Emergency stop: all agents call noop | Human |
 | `self-improvement` | PR was created by the nightly learning loop | self-improvement-meta |
+| `ci-fix` | PR was created by the CI cleaner | ci-cleaner |
 | `plan-file` | PR contains a plan file | spec-refiner |
 
-## Installing Additional Workflows
+## Implementer Routing
 
-The factory works best with two complementary workflows from the [githubnext/agentics](https://github.com/githubnext/agentics) sample pack:
+The full routing rules live in `AGENTS.md` under "Agent routing guidelines". Summary:
 
-```bash
-# Break plans into sub-issues
-gh aw add githubnext/agentics/plan
-
-# Auto-fix CI failures on PRs
-gh aw add githubnext/agentics/pr-fix
-
-# Compile and commit
-gh aw compile
-git add .github/workflows/
-git commit -m "Add plan and pr-fix workflows"
-```
-
-## Implementer Routing Guidelines
-
-The routing rules live in `AGENTS.md` under "Agent routing guidelines". The short version:
-
-**Claude Opus 4.6**: complex, multi-file, architecturally risky work. More than three modules, high blast radius, non-trivial rollback, six or more checklist items.
-
-**Claude Sonnet 4.6**: straightforward single-component features. Clear scope, existing patterns to follow, medium blast radius.
-
-**Copilot cloud agent**: trivial or highly constrained work. Dependency bumps, one-line fixes, config changes, mechanical edits.
-
-**Codex GPT-5.4**: opportunistic. Different reasoning style as a sanity check, A/B data on agent quality.
+- **Claude Opus 4.6**: complex, multi-file, architecturally risky. More than three modules, high blast radius, non-trivial rollback.
+- **Claude Sonnet 4.6**: straightforward single-component features. Clear scope, existing patterns, medium blast radius.
+- **Copilot cloud agent**: trivial or highly constrained. Dependency bumps, one-line fixes, config changes.
+- **Codex GPT-5.4**: opportunistic. Different reasoning style as a sanity check, A/B data on agent quality.
 
 The spec-refiner recommends. The human decides. The reviewer calibrates based on who actually produced the code.
 
@@ -197,8 +217,14 @@ gh aw audit <run-id>
 
 # Recompile after editing a workflow
 gh aw compile <workflow-name>
+
+# Recompile all workflows
+gh aw compile
+
+# Remove orphaned lock files
+gh aw compile --purge
 ```
 
 ## Architecture
 
-See [`chain.md`](chain.md) for the full architecture diagram, the layered adapter pattern, and the design rationale for choreography over orchestration.
+See [`chain.md`](chain.md) for the full layered architecture diagram and the design rationale for choreography over orchestration.


### PR DESCRIPTION
## Summary

Updates all three documentation files to reflect the complete 10-workflow factory chain.

### CLAUDE.md
- New "Agent Factory" section with chain overview, common tasks (add/edit/debug workflows), key file references, and human decision points
- Architecture section now lists all 10 workflow files

### AGENTS.md  
- Factory shared context now lists all three workflow tiers (factory chain, support, project-specific)
- New workflow inventory table with trigger, safe outputs, and skill for each of the 10 workflows
- Tooling section expanded with bash, edit, web-fetch tools used by support workflows

### docs/AGENT_FACTORY.md
- Complete rewrite with the full triage > spec > plan > implement > review > fix > learn chain diagram
- Separate workflow tables by tier (factory chain, support, project-specific)
- Updated quick start guide covering issue-triage, ci-cleaner, contribution-checker, /pr-fix, and /plan
- Added ci-fix label to the label reference table

## Test plan

- [ ] Verify all workflow file links resolve correctly
- [ ] Confirm AGENTS.md workflow inventory matches actual `.github/workflows/` contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)