### PR TITLE
Promote learnings to all three harness files

### DIFF
--- a/.github/workflows/self-improvement-meta.md
+++ b/.github/workflows/self-improvement-meta.md
@@ -81,7 +81,11 @@ Follow the skill's process for:
 2. Computing a stable Pattern-Key
 3. Deduplicating against existing entries in `.learnings/LEARNINGS.md`
 4. Writing new learnings using the skill's template
-5. Promoting high-priority prevention rules to `AGENTS.md` or the relevant workflow file
+5. Promoting high-priority prevention rules to all three harness files:
+   - `CLAUDE.md` (read by Claude Code at session start)
+   - `AGENTS.md` (read by gh-aw workflows and GitHub Copilot agents)
+   - `.github/copilot-instructions.md` (read by GitHub Copilot in IDE and cloud)
+   - The relevant workflow `.md` file (if the rule is workflow-specific)
 
 Skip transient infrastructure failures, rate limit hits, and failures already captured under a matching Pattern-Key.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,16 @@ Learnings live in `.learnings/LEARNINGS.md` and follow this format:
 
 Never log secrets, tokens, private keys, or full source files. Prefer short summaries over raw output. The full specification of this format lives in `.claude/skills/self-improvement/SKILL.md`.
 
+#### Promotion targets
+
+When a learning is promoted (high priority, recurrent pattern, broadly applicable), it must be written to **all three harness files** so every agent runtime benefits:
+
+1. **`AGENTS.md`**: read by gh-aw workflows and GitHub Copilot agents at run start
+2. **`.github/copilot-instructions.md`**: read by GitHub Copilot in IDE and cloud coding agent
+3. **`CLAUDE.md`**: read by Claude Code at session start
+
+If the rule is workflow-specific (only applies to one workflow), also add it to that workflow's `.md` file body. Generic rules go in the harness files only.
+
 ### Agent routing guidelines
 
 As of April 2026, GitHub offers three cloud coding agents, all bundled with the Copilot subscription: Copilot cloud agent, Claude (Sonnet 4.5/4.6, Opus 4.5/4.6), and Codex (GPT-5.2/5.3/5.4-Codex). Model selection happens when a task is kicked off on github.com. For workflows in this pack, `spec-refiner` recommends an implementer in the plan file, and a human confirms the assignment via the web UI.


### PR DESCRIPTION
## Summary

self-improvement-meta previously only promoted learnings to AGENTS.md and workflow files. Now promotes to all three harness files so every agent runtime benefits:

1. **CLAUDE.md** (Claude Code)
2. **AGENTS.md** (gh-aw workflows + GitHub Copilot agents)
3. **.github/copilot-instructions.md** (GitHub Copilot in IDE and cloud)

Plus the relevant workflow `.md` file if the rule is workflow-specific.

Also adds a "Promotion targets" section to AGENTS.md documenting this convention.

## Test plan

- [ ] Verify self-improvement-meta.md references all three files
- [ ] Verify AGENTS.md documents the promotion targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)