### PR TITLE
Add implementer-dispatcher: assign once at plan level, auto-dispatch sub-issues

### DIFF
--- a/.github/workflows/implementer-dispatcher.lock.yml
+++ b/.github/workflows/implementer-dispatcher.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6f2c8307ddae053c5ba096d45c9cb7712129361cf8088045aa6674bc192a12f9","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"55da341a2d3e1c66b00b65ec192df53637b9c8ffd42984b4c35dd51d107423bd","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_AGENT_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -25,14 +25,12 @@
 #
 # Secrets used:
 #   - COPILOT_GITHUB_TOKEN
-#   - GH_AW_CI_TRIGGER_TOKEN
+#   - GH_AW_AGENT_TOKEN
 #   - GH_AW_GITHUB_MCP_SERVER_TOKEN
 #   - GH_AW_GITHUB_TOKEN
 #   - GITHUB_TOKEN
 #
 # Custom actions used:
-#   - actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-#   - actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
 #   - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -47,7 +45,7 @@
 #   - ghcr.io/github/github-mcp-server:v0.32.0
 #   - node:lts-alpine
 
-name: "Spec Refiner"
+name: "Implementer Dispatcher"
 "on":
   issues:
     types:
@@ -65,13 +63,14 @@ permissions: {}
 concurrency:
   group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}"
 
-run-name: "Spec Refiner"
+run-name: "Implementer Dispatcher"
 
 jobs:
   activation:
     needs: pre_activation
     if: >
-      needs.pre_activation.outputs.activated == 'true' && (github.event.label.name == 'needs-spec' || github.event_name == 'workflow_dispatch')
+      needs.pre_activation.outputs.activated == 'true' && (github.event.label.name == 'ready-for-implementation' ||
+      github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -104,7 +103,7 @@ jobs:
           GH_AW_INFO_VERSION: "1.0.21"
           GH_AW_INFO_AGENT_VERSION: "1.0.21"
           GH_AW_INFO_CLI_VERSION: "v0.68.3"
-          GH_AW_INFO_WORKFLOW_NAME: "Spec Refiner"
+          GH_AW_INFO_WORKFLOW_NAME: "Implementer Dispatcher"
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
@@ -139,7 +138,7 @@ jobs:
         id: check-lock-file
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
-          GH_AW_WORKFLOW_FILE: "spec-refiner.lock.yml"
+          GH_AW_WORKFLOW_FILE: "implementer-dispatcher.lock.yml"
           GH_AW_CONTEXT_WORKFLOW_REF: "${{ github.workflow_ref }}"
         with:
           script: |
@@ -182,20 +181,16 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_4e63dd1c9f333410_EOF'
+          cat << 'GH_AW_PROMPT_854a25984c635979_EOF'
           <system>
-          GH_AW_PROMPT_4e63dd1c9f333410_EOF
+          GH_AW_PROMPT_854a25984c635979_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
-          cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_4e63dd1c9f333410_EOF'
+          cat << 'GH_AW_PROMPT_854a25984c635979_EOF'
           <safe-output-tools>
-          Tools: add_comment, update_issue, create_pull_request, add_labels(max:3), remove_labels, missing_tool, missing_data, noop
-          GH_AW_PROMPT_4e63dd1c9f333410_EOF
-          cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_4e63dd1c9f333410_EOF'
+          Tools: add_comment, add_labels, assign_to_agent, missing_tool, missing_data, noop
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -225,12 +220,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_4e63dd1c9f333410_EOF
+          GH_AW_PROMPT_854a25984c635979_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_4e63dd1c9f333410_EOF'
+          cat << 'GH_AW_PROMPT_854a25984c635979_EOF'
           </system>
-          {{#runtime-import .github/workflows/spec-refiner.md}}
-          GH_AW_PROMPT_4e63dd1c9f333410_EOF
+          {{#runtime-import .github/workflows/implementer-dispatcher.md}}
+          GH_AW_PROMPT_854a25984c635979_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -246,9 +241,6 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_ALLOWED_EXTENSIONS: ''
-          GH_AW_CACHE_DESCRIPTION: ''
-          GH_AW_CACHE_DIR: '/tmp/gh-aw/cache-memory/'
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
@@ -269,9 +261,6 @@ jobs:
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
               substitutions: {
-                GH_AW_ALLOWED_EXTENSIONS: process.env.GH_AW_ALLOWED_EXTENSIONS,
-                GH_AW_CACHE_DESCRIPTION: process.env.GH_AW_CACHE_DESCRIPTION,
-                GH_AW_CACHE_DIR: process.env.GH_AW_CACHE_DIR,
                 GH_AW_GITHUB_ACTOR: process.env.GH_AW_GITHUB_ACTOR,
                 GH_AW_GITHUB_EVENT_COMMENT_ID: process.env.GH_AW_GITHUB_EVENT_COMMENT_ID,
                 GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: process.env.GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER,
@@ -317,7 +306,7 @@ jobs:
       GH_AW_ASSETS_BRANCH: ""
       GH_AW_ASSETS_MAX_SIZE_KB: 0
       GH_AW_MCP_LOG_DIR: /tmp/gh-aw/mcp-logs/safeoutputs
-      GH_AW_WORKFLOW_ID_SANITIZED: specrefiner
+      GH_AW_WORKFLOW_ID_SANITIZED: implementerdispatcher
     outputs:
       agentic_engine_timeout: ${{ steps.detect-copilot-errors.outputs.agentic_engine_timeout || 'false' }}
       checkout_pr_success: ${{ steps.checkout-pr.outputs.checkout_pr_success || 'true' }}
@@ -356,21 +345,6 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
-      # Cache memory file share configuration from frontmatter processed below
-      - name: Create cache-memory directory
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/create_cache_memory_dir.sh"
-      - name: Restore cache-memory file share data
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          key: memory-none-nopolicy-${{ env.GH_AW_WORKFLOW_ID_SANITIZED }}-${{ github.run_id }}
-          path: /tmp/gh-aw/cache-memory
-          restore-keys: |
-            memory-none-nopolicy-${{ env.GH_AW_WORKFLOW_ID_SANITIZED }}-
-      - name: Setup cache-memory git repository
-        env:
-          GH_AW_CACHE_DIR: /tmp/gh-aw/cache-memory
-          GH_AW_MIN_INTEGRITY: none
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/setup_cache_memory_git.sh"
       - name: Configure Git credentials
         env:
           REPO_NAME: ${{ github.repository }}
@@ -417,23 +391,23 @@ jobs:
       - name: Download container images
         run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.20 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20 ghcr.io/github/gh-aw-firewall/squid:0.25.20 ghcr.io/github/gh-aw-mcpg:v0.2.19 ghcr.io/github/github-mcp-server:v0.32.0 node:lts-alpine
       - name: Write Safe Outputs Config
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_5a8b19a8f106d5db_EOF'
-          {"add_comment":{"max":1},"add_labels":{"allowed":["needs-plan","blocked-on-human","spec-refined","impl:claude-opus","impl:claude-sonnet","impl:copilot","impl:codex"],"max":3},"create_pull_request":{"labels":["plan-file","automation"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"title_prefix":"[plan] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"remove_labels":{"allowed":["needs-spec"],"max":1},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_5a8b19a8f106d5db_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_2879aaa49c424745_EOF
+          {"add_comment":{"max":1},"add_labels":{"allowed":["assigned-to-agent"],"max":1},"assign_to_agent":{"max":1,"target-repo":"${GITHUB_REPOSITORY}"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_2879aaa49c424745_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
                 "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Supports reply_to_id for discussion threading.",
-                "add_labels": " CONSTRAINTS: Maximum 3 label(s) can be added. Only these labels are allowed: [\"needs-plan\" \"blocked-on-human\" \"spec-refined\" \"impl:claude-opus\" \"impl:claude-sonnet\" \"impl:copilot\" \"impl:codex\"].",
-                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[plan] \". Labels [\"plan-file\" \"automation\"] will be automatically added.",
-                "remove_labels": " CONSTRAINTS: Maximum 1 label(s) can be removed. Only these labels can be removed: [needs-spec].",
-                "update_issue": " CONSTRAINTS: Maximum 1 issue(s) can be updated."
+                "add_labels": " CONSTRAINTS: Maximum 1 label(s) can be added. Only these labels are allowed: [\"assigned-to-agent\"].",
+                "assign_to_agent": " CONSTRAINTS: Maximum 1 issue(s) can be assigned to agent. Issues will be assigned to agent in repository \"${{ github.repository }}\"."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -481,41 +455,30 @@ jobs:
                   }
                 }
               },
-              "create_pull_request": {
+              "assign_to_agent": {
                 "defaultMax": 1,
                 "fields": {
-                  "body": {
-                    "required": true,
+                  "agent": {
                     "type": "string",
                     "sanitize": true,
-                    "maxLength": 65000
+                    "maxLength": 128
                   },
-                  "branch": {
-                    "required": true,
+                  "issue_number": {
+                    "issueNumberOrTemporaryId": true
+                  },
+                  "pull_number": {
+                    "optionalPositiveInteger": true
+                  },
+                  "pull_request_repo": {
                     "type": "string",
-                    "sanitize": true,
                     "maxLength": 256
-                  },
-                  "draft": {
-                    "type": "boolean"
-                  },
-                  "labels": {
-                    "type": "array",
-                    "itemType": "string",
-                    "itemSanitize": true,
-                    "itemMaxLength": 128
                   },
                   "repo": {
                     "type": "string",
                     "maxLength": 256
-                  },
-                  "title": {
-                    "required": true,
-                    "type": "string",
-                    "sanitize": true,
-                    "maxLength": 128
                   }
-                }
+                },
+                "customValidation": "requiresOneOf:issue_number,pull_number"
               },
               "missing_data": {
                 "defaultMax": 20,
@@ -574,25 +537,6 @@ jobs:
                   }
                 }
               },
-              "remove_labels": {
-                "defaultMax": 5,
-                "fields": {
-                  "item_number": {
-                    "issueNumberOrTemporaryId": true
-                  },
-                  "labels": {
-                    "required": true,
-                    "type": "array",
-                    "itemType": "string",
-                    "itemSanitize": true,
-                    "itemMaxLength": 128
-                  },
-                  "repo": {
-                    "type": "string",
-                    "maxLength": 256
-                  }
-                }
-              },
               "report_incomplete": {
                 "defaultMax": 5,
                 "fields": {
@@ -608,60 +552,6 @@ jobs:
                     "maxLength": 1024
                   }
                 }
-              },
-              "update_issue": {
-                "defaultMax": 1,
-                "fields": {
-                  "assignees": {
-                    "type": "array",
-                    "itemType": "string",
-                    "itemSanitize": true,
-                    "itemMaxLength": 39
-                  },
-                  "body": {
-                    "type": "string",
-                    "sanitize": true,
-                    "maxLength": 65000
-                  },
-                  "issue_number": {
-                    "issueOrPRNumber": true
-                  },
-                  "labels": {
-                    "type": "array",
-                    "itemType": "string",
-                    "itemSanitize": true,
-                    "itemMaxLength": 128
-                  },
-                  "milestone": {
-                    "optionalPositiveInteger": true
-                  },
-                  "operation": {
-                    "type": "string",
-                    "enum": [
-                      "replace",
-                      "append",
-                      "prepend",
-                      "replace-island"
-                    ]
-                  },
-                  "repo": {
-                    "type": "string",
-                    "maxLength": 256
-                  },
-                  "status": {
-                    "type": "string",
-                    "enum": [
-                      "open",
-                      "closed"
-                    ]
-                  },
-                  "title": {
-                    "type": "string",
-                    "sanitize": true,
-                    "maxLength": 128
-                  }
-                },
-                "customValidation": "requiresOneOf:status,title,body"
               }
             }
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -739,7 +629,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_dac99a3dd248e5d0_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_70cb403e3314d0aa_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -749,7 +639,7 @@ jobs:
                   "GITHUB_HOST": "\${GITHUB_SERVER_URL}",
                   "GITHUB_PERSONAL_ACCESS_TOKEN": "\${GITHUB_MCP_SERVER_TOKEN}",
                   "GITHUB_READ_ONLY": "1",
-                  "GITHUB_TOOLSETS": "issues,repos,search"
+                  "GITHUB_TOOLSETS": "issues,repos"
                 },
                 "guard-policies": {
                   "allow-only": {
@@ -780,7 +670,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_dac99a3dd248e5d0_EOF
+          GH_AW_MCP_CONFIG_70cb403e3314d0aa_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -792,14 +682,14 @@ jobs:
       - name: Execute GitHub Copilot CLI
         id: agentic_execution
         # Copilot CLI tool arguments (sorted):
-        timeout-minutes: 10
+        timeout-minutes: 5
         run: |
           set -o pipefail
           touch /tmp/gh-aw/agent-step-summary.md
           (umask 177 && touch /tmp/gh-aw/agent-stdio.log)
           # shellcheck disable=SC1003
           sudo -E awf --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --env-all --exclude-env COPILOT_GITHUB_TOKEN --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --allow-domains api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --image-tag 0.25.20 --skip-pull --enable-api-proxy \
-            -- /bin/bash -c 'node ${RUNNER_TEMP}/gh-aw/actions/copilot_driver.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-all-tools --add-dir /tmp/gh-aw/cache-memory/ --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
+            -- /bin/bash -c 'node ${RUNNER_TEMP}/gh-aw/actions/copilot_driver.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-all-tools --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
@@ -945,17 +835,6 @@ jobs:
           if [ ! -f /tmp/gh-aw/agent_output.json ]; then
             echo '{"items":[]}' > /tmp/gh-aw/agent_output.json
           fi
-      - name: Commit cache-memory changes
-        if: always()
-        env:
-          GH_AW_CACHE_DIR: /tmp/gh-aw/cache-memory
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/commit_cache_memory_git.sh"
-      - name: Upload cache-memory data as artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: always()
-        with:
-          name: cache-memory
-          path: /tmp/gh-aw/cache-memory
       - name: Upload agent artifacts
         if: always()
         continue-on-error: true
@@ -985,18 +864,17 @@ jobs:
       - agent
       - detection
       - safe_outputs
-      - update_cache_memory
     if: >
       always() && (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true' ||
       needs.activation.outputs.stale_lock_file_failed == 'true')
     runs-on: ubuntu-slim
     permissions:
-      contents: write
+      contents: read
       discussions: write
       issues: write
       pull-requests: write
     concurrency:
-      group: "gh-aw-conclusion-spec-refiner"
+      group: "gh-aw-conclusion-implementer-dispatcher"
       cancel-in-progress: false
     outputs:
       incomplete_count: ${{ steps.report_incomplete.outputs.incomplete_count }}
@@ -1031,7 +909,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: "1"
-          GH_AW_WORKFLOW_NAME: "Spec Refiner"
+          GH_AW_WORKFLOW_NAME: "Implementer Dispatcher"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_REPORT_AS_ISSUE: "true"
@@ -1047,7 +925,7 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Spec Refiner"
+          GH_AW_WORKFLOW_NAME: "Implementer Dispatcher"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.outputs.detection_conclusion }}
           GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
@@ -1064,7 +942,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_MISSING_TOOL_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "Spec Refiner"
+          GH_AW_WORKFLOW_NAME: "Implementer Dispatcher"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1078,7 +956,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_REPORT_INCOMPLETE_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "Spec Refiner"
+          GH_AW_WORKFLOW_NAME: "Implementer Dispatcher"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1092,10 +970,10 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Spec Refiner"
+          GH_AW_WORKFLOW_NAME: "Implementer Dispatcher"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
-          GH_AW_WORKFLOW_ID: "spec-refiner"
+          GH_AW_WORKFLOW_ID: "implementer-dispatcher"
           GH_AW_ENGINE_ID: "copilot"
           GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
@@ -1103,13 +981,13 @@ jobs:
           GH_AW_MCP_POLICY_ERROR: ${{ needs.agent.outputs.mcp_policy_error }}
           GH_AW_AGENTIC_ENGINE_TIMEOUT: ${{ needs.agent.outputs.agentic_engine_timeout }}
           GH_AW_MODEL_NOT_SUPPORTED_ERROR: ${{ needs.agent.outputs.model_not_supported_error }}
-          GH_AW_CODE_PUSH_FAILURE_ERRORS: ${{ needs.safe_outputs.outputs.code_push_failure_errors }}
-          GH_AW_CODE_PUSH_FAILURE_COUNT: ${{ needs.safe_outputs.outputs.code_push_failure_count }}
+          GH_AW_ASSIGNMENT_ERRORS: ${{ needs.safe_outputs.outputs.assign_to_agent_assignment_errors }}
+          GH_AW_ASSIGNMENT_ERROR_COUNT: ${{ needs.safe_outputs.outputs.assign_to_agent_assignment_error_count }}
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
           GH_AW_GROUP_REPORTS: "false"
           GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
-          GH_AW_TIMEOUT_MINUTES: "10"
+          GH_AW_TIMEOUT_MINUTES: "5"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1203,7 +1081,7 @@ jobs:
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
-          WORKFLOW_NAME: "Spec Refiner"
+          WORKFLOW_NAME: "Implementer Dispatcher"
           WORKFLOW_DESCRIPTION: "No description provided"
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
@@ -1276,7 +1154,7 @@ jobs:
             await main();
 
   pre_activation:
-    if: github.event.label.name == 'needs-spec' || github.event_name == 'workflow_dispatch'
+    if: github.event.label.name == 'ready-for-implementation' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
@@ -1310,29 +1188,30 @@ jobs:
     if: (!cancelled()) && needs.agent.result != 'skipped' && needs.detection.result == 'success'
     runs-on: ubuntu-slim
     permissions:
-      contents: write
+      contents: read
       discussions: write
       issues: write
       pull-requests: write
     timeout-minutes: 15
     env:
-      GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/spec-refiner"
+      GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/implementer-dispatcher"
       GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.outputs.detection_conclusion }}
       GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: ${{ needs.agent.outputs.model }}
-      GH_AW_WORKFLOW_ID: "spec-refiner"
-      GH_AW_WORKFLOW_NAME: "Spec Refiner"
+      GH_AW_WORKFLOW_ID: "implementer-dispatcher"
+      GH_AW_WORKFLOW_NAME: "Implementer Dispatcher"
     outputs:
+      assign_to_agent_assigned: ${{ steps.process_safe_outputs.outputs.assign_to_agent_assigned }}
+      assign_to_agent_assignment_error_count: ${{ steps.process_safe_outputs.outputs.assign_to_agent_assignment_error_count }}
+      assign_to_agent_assignment_errors: ${{ steps.process_safe_outputs.outputs.assign_to_agent_assignment_errors }}
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}
       comment_id: ${{ steps.process_safe_outputs.outputs.comment_id }}
       comment_url: ${{ steps.process_safe_outputs.outputs.comment_url }}
       create_discussion_error_count: ${{ steps.process_safe_outputs.outputs.create_discussion_error_count }}
       create_discussion_errors: ${{ steps.process_safe_outputs.outputs.create_discussion_errors }}
-      created_pr_number: ${{ steps.process_safe_outputs.outputs.created_pr_number }}
-      created_pr_url: ${{ steps.process_safe_outputs.outputs.created_pr_url }}
       process_safe_outputs_processed_count: ${{ steps.process_safe_outputs.outputs.processed_count }}
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
@@ -1357,34 +1236,6 @@ jobs:
           mkdir -p /tmp/gh-aw/
           find "/tmp/gh-aw/" -type f -print
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/agent_output.json" >> "$GITHUB_OUTPUT"
-      - name: Download patch artifact
-        continue-on-error: true
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: agent
-          path: /tmp/gh-aw/
-      - name: Checkout repository
-        if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'create_pull_request')
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.base_ref || github.event.pull_request.base.ref || github.ref_name || github.event.repository.default_branch }}
-          token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          persist-credentials: false
-          fetch-depth: 1
-      - name: Configure Git credentials
-        if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'create_pull_request')
-        env:
-          REPO_NAME: ${{ github.repository }}
-          SERVER_URL: ${{ github.server_url }}
-          GIT_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-        run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-          git config --global am.keepcr true
-          # Re-authenticate git with GitHub token
-          SERVER_URL_STRIPPED="${SERVER_URL#https://}"
-          git remote set-url origin "https://x-access-token:${GIT_TOKEN}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
-          echo "Git configured with standard GitHub Actions identity"
       - name: Configure GH_HOST for enterprise compatibility
         id: ghes-host-config
         shell: bash
@@ -1402,8 +1253,8 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"add_labels\":{\"allowed\":[\"needs-plan\",\"blocked-on-human\",\"spec-refined\",\"impl:claude-opus\",\"impl:claude-sonnet\",\"impl:copilot\",\"impl:codex\"],\"max\":3},\"create_pull_request\":{\"labels\":[\"plan-file\",\"automation\"],\"max\":1,\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"AGENTS.md\"],\"protected_path_prefixes\":[\".github/\",\".agents/\"],\"title_prefix\":\"[plan] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"remove_labels\":{\"allowed\":[\"needs-spec\"],\"max\":1},\"report_incomplete\":{},\"update_issue\":{\"allow_body\":true,\"max\":1}}"
-          GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"add_labels\":{\"allowed\":[\"assigned-to-agent\"],\"max\":1},\"assign_to_agent\":{\"max\":1,\"target-repo\":\"${{ github.repository }}\"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_ASSIGN_TO_AGENT_TOKEN: ${{ secrets.GH_AW_AGENT_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1420,47 +1271,4 @@ jobs:
             /tmp/gh-aw/safe-output-items.jsonl
             /tmp/gh-aw/temporary-id-map.json
           if-no-files-found: ignore
-
-  update_cache_memory:
-    needs:
-      - activation
-      - agent
-      - detection
-    if: >
-      always() && (needs.detection.result == 'success' || needs.detection.result == 'skipped') &&
-      needs.agent.result == 'success'
-    runs-on: ubuntu-slim
-    permissions: {}
-    env:
-      GH_AW_WORKFLOW_ID_SANITIZED: specrefiner
-    steps:
-      - name: Setup Scripts
-        id: setup
-        uses: github/gh-aw-actions/setup@ba90f2186d7ad780ec640f364005fa24e797b360 # v0.68.3
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
-          job-name: ${{ github.job }}
-          trace-id: ${{ needs.activation.outputs.setup-trace-id }}
-      - name: Download cache-memory artifact (default)
-        id: download_cache_default
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        continue-on-error: true
-        with:
-          name: cache-memory
-          path: /tmp/gh-aw/cache-memory
-      - name: Check if cache-memory folder has content (default)
-        id: check_cache_default
-        shell: bash
-        run: |
-          if [ -d "/tmp/gh-aw/cache-memory" ] && [ "$(ls -A /tmp/gh-aw/cache-memory 2>/dev/null)" ]; then
-            echo "has_content=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_content=false" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Save cache-memory to cache (default)
-        if: steps.check_cache_default.outputs.has_content == 'true'
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          key: memory-none-nopolicy-${{ env.GH_AW_WORKFLOW_ID_SANITIZED }}-${{ github.run_id }}
-          path: /tmp/gh-aw/cache-memory
 

--- a/.github/workflows/implementer-dispatcher.md
+++ b/.github/workflows/implementer-dispatcher.md
@@ -1,0 +1,66 @@
+---
+on:
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+if: github.event.label.name == 'ready-for-implementation' || github.event_name == 'workflow_dispatch'
+timeout-minutes: 5
+permissions:
+  contents: read
+  issues: read
+tools:
+  github:
+    toolsets: [issues, repos]
+safe-outputs:
+  assign-to-agent:
+    target-repo: ${{ github.repository }}
+  add-comment:
+    max: 1
+  add-labels:
+    allowed: [assigned-to-agent]
+    max: 1
+---
+
+# Implementer Dispatcher
+
+You auto-assign sub-issues to the correct cloud coding agent based on the parent issue's implementer label. This removes the need for humans to assign each sub-issue individually.
+
+## Process
+
+### Step 1: Find the parent issue
+
+This sub-issue was labeled `ready-for-implementation` by the `/plan` workflow. Find the parent issue by:
+1. Checking for a parent issue link (sub-issue relationship)
+2. Looking for a `plan-NNN` reference in the issue body
+3. Searching for the plan file referenced in the issue body and finding its source issue
+
+If no parent issue is found, post a comment explaining that manual assignment is needed and call noop.
+
+### Step 2: Read the implementer label from the parent
+
+Look for one of these labels on the parent issue:
+- `impl:claude-opus` - assign to Claude Opus 4.6
+- `impl:claude-sonnet` - assign to Claude Sonnet 4.6
+- `impl:copilot` - assign to Copilot cloud agent
+- `impl:codex` - assign to Codex
+
+If the parent issue has no implementer label, default to `impl:copilot` (the most constrained and cheapest option). Post a comment noting that no implementer was specified and the default was used.
+
+### Step 3: Assign the sub-issue
+
+Use the `assign-to-agent` safe output to assign this sub-issue to the chosen agent.
+
+Add the `assigned-to-agent` label to track that dispatch happened.
+
+Post a brief comment: "Assigned to [agent name] based on parent issue #NNN label `impl:X`."
+
+## Noop conditions
+
+Call `noop` if:
+- The issue is labeled `human-review`
+- The issue already has the `assigned-to-agent` label (prevent double-dispatch)
+- The issue is not a sub-issue (no parent found and no plan reference)
+
+## Style
+
+Follow the writing rules in `AGENTS.md`. One-line comments. No filler.

--- a/.github/workflows/spec-refiner.md
+++ b/.github/workflows/spec-refiner.md
@@ -31,8 +31,8 @@ safe-outputs:
     title-prefix: "[plan] "
     labels: [plan-file, automation]
   add-labels:
-    allowed: [needs-plan, blocked-on-human, spec-refined]
-    max: 2
+    allowed: [needs-plan, blocked-on-human, spec-refined, "impl:claude-opus", "impl:claude-sonnet", "impl:copilot", "impl:codex"]
+    max: 3
   remove-labels:
     allowed: [needs-spec]
     max: 1
@@ -68,7 +68,13 @@ Pick one of: `claude-opus-4.6`, `claude-sonnet-4.6`, `copilot`, or `codex-gpt-5.
 **Rationale**: Multi-file refactor across auth, session, and database layers with high blast radius and non-trivial rollback. Opus is the right default for this class of work.
 ```
 
-This is a recommendation, not an assignment. A human reviews the plan PR and assigns the sub-issues to the chosen agent via the github.com web UI when they kick off implementation. Do not attempt to assign anything yourself.
+After writing the recommendation in the plan file, also add the corresponding implementer label to the source issue:
+- `claude-opus-4.6` recommendation: add label `impl:claude-opus`
+- `claude-sonnet-4.6` recommendation: add label `impl:claude-sonnet`
+- `copilot` recommendation: add label `impl:copilot`
+- `codex-gpt-5.4` recommendation: add label `impl:codex`
+
+This label is the default. A human can change it on the issue before commenting `/plan`. The `implementer-dispatcher` workflow will read this label and auto-assign sub-issues to the chosen agent, so the human only decides once at the plan level.
 
 ## gh-aw handoff logic
 
@@ -78,6 +84,7 @@ After the skill completes, the plan file is written, and the implementer is reco
 2. **Comment on the source issue** with a one-line summary, a link to the plan PR, and the recommended implementer.
 3. **Swap labels**:
    - Remove `needs-spec`
+   - Add the implementer label (`impl:claude-opus`, `impl:claude-sonnet`, `impl:copilot`, or `impl:codex`)
    - Add `needs-plan` if the plan has no open questions (this triggers `/plan` to create sub-issues)
    - Add `blocked-on-human` if the plan has any `**NEEDS HUMAN INPUT**` markers
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,7 +252,7 @@ The skills in `.claude/skills/` were originally designed for Claude Code. Runnin
 
 #### How the recommendation gets made
 
-`spec-refiner` adds a `## Recommended implementer` section to every plan file. It assesses the plan against the routing rules above and writes one of: `claude-opus-4.6`, `claude-sonnet-4.6`, `copilot`, or `codex-gpt-5.4`, with a one-line rationale. The human who reviews the plan PR sees the recommendation and decides whether to follow it when assigning sub-issues.
+`spec-refiner` adds a `## Recommended implementer` section to every plan file and adds the corresponding `impl:*` label to the parent issue (e.g., `impl:claude-opus`). The human reviews the plan PR and can swap the label if they disagree. When `/plan` creates sub-issues, the `implementer-dispatcher` workflow reads the `impl:*` label from the parent issue and auto-assigns each sub-issue to the chosen agent. One decision at the plan level, zero manual assignment per sub-issue.
 
 #### A note on gh-aw engine selection
 
@@ -272,6 +272,7 @@ The routing rules above are about the **implementer step** (who writes the code 
 | Workflow | Trigger | Safe outputs | Skill |
 |----------|---------|-------------|-------|
 | `spec-refiner` | Issue labeled `needs-spec` | update-issue, add-comment, create-pull-request, add-labels, remove-labels | plan-interview |
+| `implementer-dispatcher` | Sub-issue labeled `ready-for-implementation` | assign-to-agent, add-comment, add-labels | (none, reads parent issue labels) |
 | `reviewer` | PR opened / updated | add-comment, add-labels | dx-data-navigator, intent-framed-agent |
 | `self-improvement-meta` | Nightly (~2am) | create-pull-request, create-issue | self-improvement |
 | `ci-cleaner` | CI failure on main | create-pull-request | (none, uses bash/edit directly) |

--- a/docs/AGENT_FACTORY.md
+++ b/docs/AGENT_FACTORY.md
@@ -14,13 +14,16 @@ issue-triage (auto-labels by type, detects spam)
 human adds "needs-spec" label
   |
   v
-spec-refiner (structured plan file + implementer recommendation)
+spec-refiner (plan file + implementer label on issue)
+  |
+  v
+human reviews plan PR, optionally swaps implementer label  <-- ONE decision
   |
   v
 /plan (breaks plan into sub-issues)
   |
   v
-human assigns sub-issues to Claude / Copilot / Codex
+implementer-dispatcher (auto-assigns sub-issues from parent label)
   |
   v
 PR opened
@@ -63,26 +66,31 @@ After triage, add the `needs-spec` label to start the factory chain.
 The `spec-refiner` workflow triggers. It reads the issue, runs the `plan-interview` skill, and produces:
 - A plan file at `docs/plans/plan-NNN-<slug>.md` (opened as a PR)
 - A recommended implementer (Claude Opus 4.6, Claude Sonnet 4.6, Copilot, or Codex)
+- An implementer label on the issue (`impl:claude-opus`, `impl:claude-sonnet`, `impl:copilot`, or `impl:codex`)
 - A label swap: `needs-spec` removed, `needs-plan` added
 
 If the agent cannot answer something from context alone, it marks the gap with **NEEDS HUMAN INPUT** and adds the `blocked-on-human` label. Add a comment with the missing context, remove the label, and re-trigger.
 
-### Step 3: Review and Approve the Plan
+### Step 3: Review the Plan and Choose an Implementer
 
-Read the plan PR. Check the success criteria, the implementation checklist, and the recommended implementer. If it looks right, merge it.
+Read the plan PR. Check the success criteria, the implementation checklist, and the recommended implementer.
 
-The `needs-plan` label triggers the `/plan` workflow, which breaks the plan into sub-issues labeled `ready-for-implementation`.
+The spec-refiner already added an implementer label (e.g., `impl:claude-opus`) to the issue based on its complexity assessment. If you disagree with the recommendation, swap the label before proceeding:
 
-### Step 4: Assign an Implementer
+| Label | Agent | When to use |
+|-------|-------|-------------|
+| `impl:claude-opus` | Claude Opus 4.6 | Multi-file refactors, high blast radius, 6+ checklist items |
+| `impl:claude-sonnet` | Claude Sonnet 4.6 | Single-component features, medium complexity |
+| `impl:copilot` | Copilot | Trivial fixes, dependency bumps, config changes |
+| `impl:codex` | Codex GPT-5.4 | A/B comparison, different reasoning style |
 
-Open each sub-issue on github.com. Go to the Agents tab and assign it to the recommended agent:
+Merge the plan PR. The `needs-plan` label triggers the `/plan` workflow, which breaks the plan into sub-issues labeled `ready-for-implementation`.
 
-| Implementer | When to use |
-|-------------|-------------|
-| **Claude Opus 4.6** | Multi-file refactors, high blast radius, 6+ checklist items |
-| **Claude Sonnet 4.6** | Single-component features, medium complexity |
-| **Copilot** | Trivial fixes, dependency bumps, config changes |
-| **Codex GPT-5.4** | A/B comparison, different reasoning style |
+### Step 4: Auto-Assignment (No Manual Work)
+
+The `implementer-dispatcher` workflow triggers automatically when sub-issues receive the `ready-for-implementation` label. It reads the implementer label from the parent issue and assigns each sub-issue to the chosen agent via `assign-to-agent`.
+
+You assigned once at Step 3. Every sub-issue inherits that choice. No manual assignment needed.
 
 The agent opens a PR with its implementation.
 
@@ -140,6 +148,7 @@ When you merge that PR, the next run of the affected agent reads the updated ins
 | [`spec-refiner.md`](../.github/workflows/spec-refiner.md) | Issue labeled `needs-spec` | Structured plan file from issue context using plan-interview skill |
 | [`reviewer.md`](../.github/workflows/reviewer.md) | PR opened / updated | Plan-aware code review with implementer calibration |
 | [`self-improvement-meta.md`](../.github/workflows/self-improvement-meta.md) | Nightly (~2am) | Extract learnings from failures, commit prevention rules |
+| [`implementer-dispatcher.md`](../.github/workflows/implementer-dispatcher.md) | Sub-issue labeled `ready-for-implementation` | Auto-assign to agent based on parent issue's implementer label |
 | [`ci-cleaner.md`](../.github/workflows/ci-cleaner.md) | CI failure on main | Auto-fix lint, test, and compilation issues |
 | [`contribution-checker.md`](../.github/workflows/contribution-checker.md) | PR opened / updated | Evaluate PR against CONTRIBUTING.md guidelines |
 
@@ -183,6 +192,11 @@ Skills live in `.claude/skills/` and work identically in Claude Code, Codex CLI,
 | `blocked-on-human` | Agent needs human input before proceeding | spec-refiner |
 | `spec-refined` | Spec refinement is complete | spec-refiner |
 | `ready-for-implementation` | Sub-issue ready for a coding agent | /plan |
+| `impl:claude-opus` | Assign to Claude Opus 4.6 | spec-refiner (or human) |
+| `impl:claude-sonnet` | Assign to Claude Sonnet 4.6 | spec-refiner (or human) |
+| `impl:copilot` | Assign to Copilot cloud agent | spec-refiner (or human) |
+| `impl:codex` | Assign to Codex GPT-5.4 | spec-refiner (or human) |
+| `assigned-to-agent` | Sub-issue has been dispatched | implementer-dispatcher |
 | `ai-reviewed` | PR passed automated review, ready for human review | reviewer |
 | `needs-changes` | PR has critical findings or spec drift | reviewer |
 | `fast-track` | Small, well-tested, matches plan, zero findings | reviewer |


### PR DESCRIPTION
## Summary

Eliminates per-sub-issue manual assignment. The human now makes one implementer decision at the plan level, and sub-issues are auto-assigned.

### Before
```
spec-refiner -> /plan creates 5 sub-issues -> human assigns each one manually
```

### After
```
spec-refiner (adds impl:claude-opus label)
  -> human reviews plan, optionally swaps label  <-- ONE decision
  -> /plan creates 5 sub-issues
  -> implementer-dispatcher auto-assigns all 5
```

## Changes

- **spec-refiner.md**: now adds an `impl:*` label to the parent issue based on complexity assessment (`impl:claude-opus`, `impl:claude-sonnet`, `impl:copilot`, `impl:codex`)
- **implementer-dispatcher.md** (new): triggers on `ready-for-implementation` label, reads parent issue's `impl:*` label, assigns sub-issue to the chosen agent via `assign-to-agent`
- **AGENTS.md**: updated routing guidelines and workflow inventory
- **docs/AGENT_FACTORY.md**: updated chain diagram, step-by-step guide, workflow tables, and label reference

## New labels

| Label | Purpose |
|-------|---------|
| `impl:claude-opus` | Route to Claude Opus 4.6 |
| `impl:claude-sonnet` | Route to Claude Sonnet 4.6 |
| `impl:copilot` | Route to Copilot cloud agent |
| `impl:codex` | Route to Codex GPT-5.4 |
| `assigned-to-agent` | Tracks that dispatch happened (prevents double-dispatch) |

## Test plan

- [ ] Open issue, label `needs-spec`, verify spec-refiner adds `impl:*` label
- [ ] Comment `/plan`, verify sub-issues get `ready-for-implementation` label
- [ ] Verify implementer-dispatcher fires and assigns sub-issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)