### PR TITLE
ci: make AI proficiency assessment manual-only

### DIFF
--- a/.github/workflows/ai-proficiency-claude.yml
+++ b/.github/workflows/ai-proficiency-claude.yml
@@ -13,8 +13,6 @@
 name: AI Proficiency Assessment (Claude)
 
 on:
-  pull_request:
-    types: [opened, synchronize]
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -32,9 +30,8 @@ permissions:
 
 jobs:
   assess-proficiency:
-    # Only run on PR events, workflow dispatch, or /assess-proficiency comments
+    # Only run via manual dispatch or /assess-proficiency comments
     if: |
-      github.event_name == 'pull_request' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/assess-proficiency'))
     runs-on: ubuntu-latest

--- a/.github/workflows/ai-proficiency-pr-review.lock.yml
+++ b/.github/workflows/ai-proficiency-pr-review.lock.yml
@@ -49,10 +49,6 @@ name: "AI Proficiency Assessment for Pull Requests"
   issue_comment:
     types:
     - created
-  pull_request:
-    types:
-    - opened
-    - synchronize
   workflow_dispatch:
     inputs:
       aw_context:

--- a/.github/workflows/ai-proficiency-pr-review.md
+++ b/.github/workflows/ai-proficiency-pr-review.md
@@ -1,7 +1,5 @@
 ---
 on:
-  pull_request:
-    types: [opened, synchronize]
   issue_comment:
     types: [created]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Removes the `pull_request: [opened, synchronize]` trigger from `ai-proficiency-pr-review` so the assessment no longer runs on every PR
- Workflow still runs via:
  - `/assess-proficiency` comment on any issue or PR
  - Manual `workflow_dispatch` from the Actions tab
- Both `.md` source and compiled `.lock.yml` updated in lockstep; no `gh aw compile` required to take effect

## Rationale
Per session on 2026-04-16, running the proficiency scorer on every PR was noisy and unnecessary when authors aren't asking for feedback. Keeping the comment trigger preserves the on-demand path without the auto-fire cost.

## Test plan
- [ ] Verify no new run of `ai-proficiency-pr-review` fires when a PR is opened or pushed to
- [ ] Verify a `/assess-proficiency` comment on an issue or PR still triggers the workflow
- [ ] Verify manual `workflow_dispatch` still works from the Actions tab

https://claude.ai/code/session_01B9KBfxn3vYQqFcA8MKjVka