### PR TITLE
ci: surgical revert of engine blocks to fix agentics lock-file hash

### DIFF
--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -11,10 +11,6 @@ on:
     types: [opened, reopened]
   reaction: eyes
 
-engine:
-  id: copilot
-  model: gpt-5.4
-
 permissions: read-all
 
 network: defaults

--- a/.github/workflows/plan.md
+++ b/.github/workflows/plan.md
@@ -7,10 +7,6 @@ on:
     name: plan
     events: [issue_comment, discussion_comment]
 
-engine:
-  id: copilot
-  model: gpt-5.4
-
 permissions:
   contents: read
   discussions: read

--- a/.github/workflows/pr-fix.md
+++ b/.github/workflows/pr-fix.md
@@ -11,10 +11,6 @@ on:
     name: pr-fix
   reaction: "eyes"
 
-engine:
-  id: copilot
-  model: gpt-5.4
-
 permissions: read-all
 
 network: defaults


### PR DESCRIPTION
## Summary
Single-commit fix to remove stray `engine:` blocks from `plan.md`, `pr-fix.md`, and `issue-triage.md`. Opening this as a focused PR against main because PR #77's attempt to do the same did not land (main still has the blocks).

## Root cause
PR #65 added `engine: id: copilot, model: gpt-5.4` to the three agentics workflow `.md` files. That altered the frontmatter gh-aw hashes and stores in each `.lock.yml` metadata header. Without `gh aw compile` regenerating the hash, gh-aw's activation step rejects every run with:

```
ERR_CONFIG: Lock file is outdated! The workflow file frontmatter has changed.
```

Confirmed today: run `24531975259` (`/plan` on issue #61) failed at activation with exactly this error. All four `/plan` comments on #61, #62, #66, #70 produced no sub-issues as a result.

## Why this revert is safe
Each `.lock.yml` still defaults `COPILOT_MODEL` to `gpt-5.4` via:
```yaml
COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || 'gpt-5.4' }}
```
so the runtime pin stays in place. The only thing removed is the source-of-truth declaration in the `.md`, pending a proper `gh aw compile` run.

## Follow-up
On a machine with `gh aw` CLI:
1. Re-add `engine: id: copilot, model: gpt-5.4` to all three `.md` files
2. `gh aw compile plan pr-fix issue-triage`
3. Commit the regenerated `.lock.yml` files — hashes will then match

## Test plan
- [ ] Post `/plan` on a test issue after merge; verify activation passes and a sub-issue is created
- [ ] Re-post `/plan` on #61, #62, #66, #70 and confirm sub-issues spawn
- [ ] Verify `issue-triage` runs cleanly on next new issue

https://claude.ai/code/session_01B9KBfxn3vYQqFcA8MKjVka