### PR TITLE
ci: implementer-dispatcher also fires on issues.opened with pre-applied label

### DIFF
--- a/.github/workflows/implementer-dispatcher.lock.yml
+++ b/.github/workflows/implementer-dispatcher.lock.yml
@@ -49,6 +49,7 @@ name: "Implementer Dispatcher"
 "on":
   issues:
     types:
+    - opened
     - labeled
   workflow_dispatch:
     inputs:
@@ -69,8 +70,9 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      needs.pre_activation.outputs.activated == 'true' && (github.event.label.name == 'ready-for-implementation' ||
-      github.event_name == 'workflow_dispatch')
+      needs.pre_activation.outputs.activated == 'true' && (github.event_name == 'workflow_dispatch' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'ready-for-implementation') ||
+      (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'ready-for-implementation')))
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -1154,7 +1156,10 @@ jobs:
             await main();
 
   pre_activation:
-    if: github.event.label.name == 'ready-for-implementation' || github.event_name == 'workflow_dispatch'
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'ready-for-implementation') ||
+      (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'ready-for-implementation'))
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}


### PR DESCRIPTION
## Summary
`implementer-dispatcher` never saw the 16 sub-issues created today from plans for #61, #62, #66, #70. They all sat unassigned until a manual label-cycle workaround forced the `labeled` event to fire on each one.

Root cause: GitHub's `issues.labeled` event only fires when a label is added **after** issue creation. `/plan` creates sub-issues WITH `ready-for-implementation` already in the label set (via `safe-outputs.create-issue.labels`). The `issues.opened` event carries those pre-applied labels, but dispatcher wasn't subscribed to it.

## Change
Lock-file-only edit (to avoid the frontmatter hash mismatch from editing `.md`, per the pattern established in #78). Three surgical changes in `.github/workflows/implementer-dispatcher.lock.yml`:

1. `"on".issues.types`: add `opened`
2. `activation` job `if:` — add third disjunct: `(github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'ready-for-implementation'))`
3. `pre_activation` job `if:` — same third disjunct

Strictly additive. The `labeled` path is unchanged.

## Follow-up
When `gh aw` CLI is available, update `.github/workflows/implementer-dispatcher.md` to `types: [opened, labeled]` and recompile so the source matches. That's blocked on #95 (lock-file hash coupling) until we have a proper CI check.

## Test plan
- [ ] After merge, file a new `needs-spec` issue, promote to `needs-plan`, comment `/plan`
- [ ] Verify each created sub-issue triggers an `implementer-dispatcher` run and gets `assigned-to-agent` label + a Copilot/Claude assignment
- [ ] Verify existing labeled-trigger behavior (manual label add) still works

## Related
- Workaround applied to today's 16 sub-issues: re-label cycle on #79-#94 to force the `labeled` event
- Connects to #96 (auto-trigger `/plan`) and #95 (lock-file hash CI check)

https://claude.ai/code/session_01B9KBfxn3vYQqFcA8MKjVka