### PR TITLE
ci: ai-proficiency-pr-review skips non-/assess-proficiency comments

### DIFF
--- a/.github/workflows/ai-proficiency-pr-review.lock.yml
+++ b/.github/workflows/ai-proficiency-pr-review.lock.yml
@@ -69,7 +69,8 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      needs.pre_activation.outputs.activated == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id)
+      needs.pre_activation.outputs.activated == 'true' && (github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/assess-proficiency')))
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -1110,7 +1111,9 @@ jobs:
             await main();
 
   pre_activation:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/assess-proficiency'))
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}


### PR DESCRIPTION
## Summary
`ai-proficiency-pr-review` is firing on every comment the factory posts because its `issue_comment: [created]` trigger has no body filter. Today alone ~60+ runs appeared on the Actions tab as noise, many stuck at "Approve and run" gates, showing as failures.

## Root cause
`.lock.yml` activation guards only check pull_request same-repo (unreachable since #57 removed the pull_request trigger). Nothing checks whether the comment body contains `/assess-proficiency`. So every `/plan`, `/pr-fix`, reviewer verdict, dispatcher assignment, eval result, and contribution-check comment fires a run.

## Change
`.lock.yml`-only surgical edit to both `pre_activation` and `activation` job `if:` guards:

```yaml
if: >
  github.event_name == 'workflow_dispatch' ||
  (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/assess-proficiency'))
```

- Passes through manual `workflow_dispatch` runs unchanged
- Passes through `/assess-proficiency` comments (the intended use case)
- Skips all other comments silently — no run entry, no approval gate, no noise

`ai-proficiency-claude.yml` already has this check at its job level, so it's not included in this PR.

## Durable fix
The gh-aw-native pattern for this is `on: slash_command: name: assess-proficiency` (how `plan.md` and `pr-fix.md` work). That requires a `.md` frontmatter edit plus `gh aw compile`, blocked on #95 landing or a local `gh aw` invocation.

## Test plan
- [ ] After merge, post a non-`/assess-proficiency` comment on any issue — verify no workflow run is created
- [ ] Post `/assess-proficiency` on an issue or PR — verify the workflow runs and the agent proceeds
- [ ] Trigger via workflow_dispatch from the Actions tab — verify the run starts

## Related
- #57 (removed the pull_request trigger from this workflow)
- #95 (CI hash check — would make the proper `.md` fix safe)

https://claude.ai/code/session_01B9KBfxn3vYQqFcA8MKjVka