### PR TITLE
fix: plan-merged-dispatcher must use a PAT so implementer-dispatcher cascades

### DIFF
--- a/.github/workflows/plan-merged-dispatcher.yml
+++ b/.github/workflows/plan-merged-dispatcher.yml
@@ -25,7 +25,12 @@ jobs:
 
       - name: Activate source issues from merged plan files
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Must be a PAT, not the default GITHUB_TOKEN. Events produced by
+          # GITHUB_TOKEN do not trigger downstream workflows (GitHub's
+          # anti-loop rule), which would leave `implementer-dispatcher`
+          # inert on the `ready-for-implementation` label we add below.
+          # Same pattern as `ci-cleaner` and `simplify-and-harden-ci`.
+          GH_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
Follow-up on #138. The smoke test on #140 surfaced that `plan-merged-dispatcher` did its job (wrote the checklist onto the source issue body, transitioned \`needs-plan\` → \`ready-for-implementation\`) but \`implementer-dispatcher\` never fired afterward.

## Cause

GitHub's anti-loop rule: events produced via the default \`GITHUB_TOKEN\` do not trigger other workflow runs. Since \`plan-merged-dispatcher\` was using \`secrets.GITHUB_TOKEN\` for its \`gh issue edit --add-label\` call, the resulting \`issues.labeled\` event was silently dropped by the factory.

Result: the chain stalled at \`ready-for-implementation\` with no agent ever picking the issue up.

## Fix

One-line token swap: \`secrets.GITHUB_TOKEN\` → \`secrets.GH_AW_CI_TRIGGER_TOKEN\` (the PAT already defined for exactly this pattern, used by \`ci-cleaner\` and \`simplify-and-harden-ci\`).

Comment block added above the \`env:\` entry to document the reason so this doesn't get reverted by a future well-meaning cleanup pass.

## Verification

\`#140\` was unblocked manually by toggling the \`ready-for-implementation\` label from a user PAT (human-triggered label events do cascade). After this PR lands, any future plan PR merge will chain straight through: \`plan-merged-dispatcher\` → labels → \`implementer-dispatcher\` → Copilot assigned.

Refs #138, #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)