### PR TITLE
fix: plan-merged-dispatcher references a secret that doesn't exist

### DIFF
--- a/.github/workflows/plan-merged-dispatcher.yml
+++ b/.github/workflows/plan-merged-dispatcher.yml
@@ -29,8 +29,11 @@ jobs:
           # GITHUB_TOKEN do not trigger downstream workflows (GitHub's
           # anti-loop rule), which would leave `implementer-dispatcher`
           # inert on the `ready-for-implementation` label we add below.
-          # Same pattern as `ci-cleaner` and `simplify-and-harden-ci`.
-          GH_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
+          # Uses GH_AW_AGENT_TOKEN because it already exists as a
+          # configured secret in this repo (GH_AW_CI_TRIGGER_TOKEN was
+          # referenced by an earlier fix but never existed) and is
+          # scoped for issue editing + label-event cascades.
+          GH_TOKEN: ${{ secrets.GH_AW_AGENT_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## The bug

#143 swapped \`plan-merged-dispatcher\`'s \`GH_TOKEN\` from \`secrets.GITHUB_TOKEN\` to \`secrets.GH_AW_CI_TRIGGER_TOKEN\` to make its \`ready-for-implementation\` label cascade into \`implementer-dispatcher\` (workaround for GitHub's anti-loop rule on GITHUB_TOKEN-produced events).

Caught today: **\`GH_AW_CI_TRIGGER_TOKEN\` is not a configured repository secret.** GitHub silently substitutes empty string for references to missing secrets, so \`gh\` CLI inside the workflow has been running unauthenticated since #143 merged.

## How it surfaced

The user merged plan PR #155. \`plan-merged-dispatcher\` fired, returned success, but #149 was not activated:

- \`has_checklist: false\` (the delimited block was never written)
- \`labels: ["enhancement", "needs-plan", "impl:claude-sonnet", ...]\` (\`needs-plan\` not stripped, \`ready-for-implementation\` not added)

The dispatcher log shows the smoking gun:

\`\`\`
No plan files in this PR. Nothing to activate.
\`\`\`

That message comes from the branch of the script where \`gh pr diff "\$PR_NUMBER" --name-only\` returns no results. Running the same command locally on #155 returns the plan file fine — the difference is token auth.

## The fix

One-line swap: \`secrets.GH_AW_CI_TRIGGER_TOKEN\` → \`secrets.GH_AW_AGENT_TOKEN\`. AGENT_TOKEN is a configured secret in this repo, has write scope for issue editing, and (being a PAT) cascades label events into downstream workflows — exactly what the #143 fix intended.

Added a comment explaining the token choice so the next operator doesn't swap back to a nonexistent secret.

## Adjacent risk worth auditing

Every other agent-backed lock file references \`GH_AW_CI_TRIGGER_TOKEN\`, \`GH_AW_GITHUB_TOKEN\`, and \`GH_AW_GITHUB_MCP_SERVER_TOKEN\` — none of which exist as secrets. gh-aw may fall back to \`GITHUB_TOKEN\` gracefully (otherwise more workflows would be broken) but it's worth a follow-up pass to either create these secrets or remove the references so the surface is honest.

## Verification

- #149 was manually activated earlier so the factory flow could continue.
- After this PR merges, the next plan PR merge (e.g. #154 for plan-152 when you get to it) will exercise the fixed path and either confirm the fix or surface the next layer.

Refs #97, #138, #143, #149, #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)