### PR TITLE
fix: agent-activity-tracker couldn't identify PRs (wrong payload field)

### DIFF
--- a/.github/workflows/agent-activity-tracker.yml
+++ b/.github/workflows/agent-activity-tracker.yml
@@ -85,9 +85,22 @@ jobs:
               MODEL=""
             fi
 
-            # Extract triggering issue/PR number from the run's event payload.
-            ITEM_NUM=$(gh api "repos/$REPO/actions/runs/$RUN_ID" \
-              --jq '.. | .number? | numbers' | head -1)
+            # Extract triggering PR number from the run's event payload.
+            # For `pull_request` / `pull_request_target`: `.pull_requests[0].number`.
+            # For `issues` events: GitHub does not expose the issue number on
+            # the run object, so we skip (v1 limitation; most issues-triggered
+            # factory workflows complete in under 3 minutes and would be missed
+            # by a 5-minute poll anyway).
+            RUN_EVENT=$(echo "$RUN" | jq -r '.event')
+            case "$RUN_EVENT" in
+              pull_request|pull_request_target)
+                ITEM_NUM=$(gh api "repos/$REPO/actions/runs/$RUN_ID" \
+                  --jq '.pull_requests[0].number // empty')
+                ;;
+              *)
+                ITEM_NUM=""
+                ;;
+            esac
             if [ -z "$ITEM_NUM" ]; then
               continue
             fi


### PR DESCRIPTION
## Summary

The tracker merged in #165 applied zero labels on its first run. Root cause: `gh api .../runs/ID --jq '.. | .number? | numbers' | head -1` returned the run's own number first, not the triggering PR number.

## Fix

Switch to `.pull_requests[0].number` and only attempt detection for `pull_request` / `pull_request_target` events. Issues-triggered runs get skipped with a comment explaining the limitation — GitHub's run payload does not expose the issue number, and those workflows complete in <3 minutes anyway, usually missed by a 5-minute poll.

## Test plan

- [ ] Merge
- [ ] `gh workflow run agent-activity-tracker.yml`
- [ ] Confirm open PRs with in-progress factory runs (reviewer, contribution-checker, etc.) get the `agent-working` + `model:gpt-5.4` labels
- [ ] Wait for runs to finish, confirm labels are swept off

🤖 Generated with [Claude Code](https://claude.com/claude-code)