### PR TITLE
fix: bulletproof plan PRs against closing-keyword auto-close (#171)

### DIFF
--- a/.github/workflows/plan-merged-dispatcher.yml
+++ b/.github/workflows/plan-merged-dispatcher.yml
@@ -99,6 +99,18 @@ jobs:
               printf '%s\n' "$marker_end"
             } > /tmp/issue_body.md
 
+            # Defense in depth: a plan PR that contained a closing keyword
+            # (Closes/Fixes/Resolves #NN) will have auto-closed the source
+            # issue on merge. A closed issue cannot be assigned to Copilot,
+            # so the implementer-dispatcher cascade silently dies. Detect
+            # that state and reopen, with a comment pointing at the bug.
+            issue_state=$(gh issue view "$issue_num" --json state --jq .state 2>/dev/null || echo "")
+            if [ "$issue_state" = "CLOSED" ]; then
+              echo "Source issue #$issue_num was auto-closed by plan PR merge (closing keyword in body). Reopening."
+              gh issue reopen "$issue_num" --comment \
+                "Auto-reopened by plan-merged-dispatcher: the plan PR body contained a closing keyword (Closes/Fixes/Resolves) that GitHub honored on merge. Plan PRs must use \`Refs #NN\` only. Tracked in spec-refiner hardening." 2>/dev/null || true
+            fi
+
             gh issue edit "$issue_num" --body-file /tmp/issue_body.md
             gh issue edit "$issue_num" --remove-label needs-plan 2>/dev/null || true
             gh issue edit "$issue_num" --remove-label needs-spec 2>/dev/null || true

--- a/.github/workflows/spec-refiner.md
+++ b/.github/workflows/spec-refiner.md
@@ -63,7 +63,17 @@ After writing the recommendation in the plan file, add the `impl:copilot` label 
 
 After the skill completes, the plan file is written, and the implementer is recommended:
 
-1. **Open a PR** with the new plan file at `docs/plans/plan-NNN-<slug>.md` where NNN is the source issue number, zero-padded to at least three digits (e.g., issue #7 → `007`, issue #42 → `042`, issue #1234 → `1234`). Do not scan `docs/plans/` for the next sequential number. Title: `[plan] Plan NNN: <title>` using the same padded issue number. Body references the source issue with `Refs #NN` (not a closing keyword such as `Closes` or `Fixes`). The plan PR must not close the source issue on merge. The body also summarizes the key decisions and restates the implementer recommendation.
+1. **Open a PR** with the new plan file at `docs/plans/plan-NNN-<slug>.md` where NNN is the source issue number, zero-padded to at least three digits (e.g., issue #7 → `007`, issue #42 → `042`, issue #1234 → `1234`). Do not scan `docs/plans/` for the next sequential number. Title: `[plan] Plan NNN: <title>` using the same padded issue number.
+
+   **CRITICAL — plan PR body rules. Read every bullet. Re-read before writing the body:**
+
+   - Reference the source issue with exactly `Refs #NN` at the top.
+   - **NEVER** write `Closes #NN`, `Close #NN`, `Closed #NN`, `Fixes #NN`, `Fix #NN`, `Fixed #NN`, `Resolves #NN`, `Resolve #NN`, `Resolved #NN`, or any of these keywords anywhere in the body, even in sub-lists, footers, or checklists. GitHub auto-closes the linked issue on merge when it sees any of those keywords; a plan PR must not close its source issue.
+   - Do not include a `- Fixes #NN` bullet in any "Summary" or "Changes" section.
+   - Before finalizing the body, grep your own draft for `/\\b(close[sd]?|fix(es|ed)?|resolve[sd]?) #\\d/i` — if anything matches, rewrite it to `Refs #NN` or remove the line.
+   - Safe synonyms: `Refs #NN`, `For #NN`, `Part of #NN`, `Tracks #NN`, `See #NN`. Use these instead of closing keywords.
+
+   The body also summarizes the key decisions and restates the implementer recommendation.
 2. **Comment on the source issue** with a one-line summary, a link to the plan PR, and the recommended implementer.
 3. **Swap labels**:
    - Remove `needs-spec`


### PR DESCRIPTION
## Summary

Direct PR for #171 — the factory bug where spec-refiner kept writing `Fixes #NN` in plan PR bodies, causing GitHub to auto-close the source issue on plan-PR merge. Bypassing the factory because shipping it *through* the factory would have hit the same bug on the plan PR merge.

Two layers of fix:

### 1. Spec-refiner prompt hardening

Escalate the closing-keyword rule from one parenthetical aside to a standalone CRITICAL block. Explicit list of every forbidden variant (`Closes/Close/Closed/Fixes/Fix/Fixed/Resolves/Resolve/Resolved`), a regex self-check the model runs against its own draft, and safe synonyms to use instead (`Refs`, `For`, `Part of`, `Tracks`, `See`).

### 2. plan-merged-dispatcher defensive reopen

If the dispatcher fires on a plan-PR merge and finds the source issue `CLOSED`, reopen it with a comment explaining the bug. Survives any future spec-refiner regression — the factory self-corrects instead of silently dying.

## Evidence this is needed

Today alone, **three** source issues got auto-closed by this bug:

- #161 — plan PR #164 had `Fixes #161`, closed on merge, manual reopen
- #169 — plan PR #170 had `Fixes #169`, closed on merge, manual reopen
- #171 — plan PR #173 had `Fixes #171`, closed on merge (the very issue this PR fixes), manual reopen

Each required a human to reopen + re-toggle `ready-for-implementation` to get Copilot moving again. Defense-in-depth removes that toil.

## Test plan

- [ ] Merge this PR
- [ ] Confirm the reopen-on-close path fires if a future plan PR slips through with a closing keyword (manual test: temporarily add `Fixes #X` to a plan PR body, merge, watch plan-merged-dispatcher reopen #X)
- [ ] Next spec-refiner run on a new `needs-spec` issue: confirm the plan PR body does NOT contain any closing keywords

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)