### PR TITLE
feat: detect 2026 context-engineering signals and gate Levels 6–8 on them

### DIFF
--- a/.evals/EVAL_INDEX.md
+++ b/.evals/EVAL_INDEX.md
@@ -17,6 +17,7 @@ Managed by `self-improvement-meta` (creates eval cases for promoted learnings) a
 | [EVAL-010](.evals/cases/EVAL-010.md) | June 2026 signal enhancement — dynamic workflows / orchestration (L8 gate) | `measure_ai_proficiency/signals.py` | grep-check | `key="dynamic_workflows"` |
 | [EVAL-011](.evals/cases/EVAL-011.md) | June 2026 signal enhancement — curricula on-ramps | `measure_ai_proficiency/signals.py` | grep-check | `key="curricula"` |
 | [EVAL-012](.evals/cases/EVAL-012.md) | June 2026 rewire — L6-L8 require context-engineering signals, not file coverage alone | `measure_ai_proficiency/scanner.py` | grep-check | `def _compute_signal_gates` |
+| [EVAL-013](.evals/cases/EVAL-013.md) | June 2026 — conciseness/anti-bloat for always-on files (CLAUDE.md/AGENTS.md) | `measure_ai_proficiency/scanner.py` | grep-check | `def _analyze_conciseness` |
 
 ## Retired cases
 

--- a/.evals/EVAL_INDEX.md
+++ b/.evals/EVAL_INDEX.md
@@ -11,6 +11,12 @@ Managed by `self-improvement-meta` (creates eval cases for promoted learnings) a
 | [EVAL-004](.evals/cases/EVAL-004.md) | spec-refiner `Fixes #NN` bug (`.learnings/ERRORS.md`, 2026-04-17) — prompt-side | `.github/workflows/spec-refiner.md` | grep-check | `Before finalizing the body, grep your own draft` |
 | [EVAL-005](.evals/cases/EVAL-005.md) | impl PR #187 merged without `Closes #186`, issue hand-closed (2026-04-18) — reviewer requires keyword | `.github/workflows/reviewer.md` | grep-check | `impl PR must close its source issue` |
 | [EVAL-006](.evals/cases/EVAL-006.md) | spec-refiner slipped `Closes #234` into plan PR #236 despite prompt prohibition (2026-04-18) — reviewer forbids keyword on plan PRs | `.github/workflows/reviewer.md` | grep-check | `Check for forbidden closing keyword (plan PRs only)` |
+| [EVAL-007](.evals/cases/EVAL-007.md) | June 2026 signal enhancement — verification signal (docs' #1, L6 gate) | `measure_ai_proficiency/signals.py` | grep-check | `key="verification"` |
+| [EVAL-008](.evals/cases/EVAL-008.md) | June 2026 signal enhancement — anti-drift maintenance hygiene (L7 gate) | `measure_ai_proficiency/signals.py` | grep-check | `key="maintenance_hygiene"` |
+| [EVAL-009](.evals/cases/EVAL-009.md) | June 2026 signal enhancement — harness-engineering proxy | `measure_ai_proficiency/signals.py` | grep-check | `key="harness_engineering"` |
+| [EVAL-010](.evals/cases/EVAL-010.md) | June 2026 signal enhancement — dynamic workflows / orchestration (L8 gate) | `measure_ai_proficiency/signals.py` | grep-check | `key="dynamic_workflows"` |
+| [EVAL-011](.evals/cases/EVAL-011.md) | June 2026 signal enhancement — curricula on-ramps | `measure_ai_proficiency/signals.py` | grep-check | `key="curricula"` |
+| [EVAL-012](.evals/cases/EVAL-012.md) | June 2026 rewire — L6-L8 require context-engineering signals, not file coverage alone | `measure_ai_proficiency/scanner.py` | grep-check | `def _compute_signal_gates` |
 
 ## Retired cases
 

--- a/.evals/cases/EVAL-007.md
+++ b/.evals/cases/EVAL-007.md
@@ -1,0 +1,38 @@
+---
+eval-id: EVAL-007
+source-learning: June 2026 signal enhancement — verification is the docs' #1 signal yet absent from the original proposal; added as an L6 gate requirement
+target: measure_ai_proficiency/signals.py
+method: grep-check
+expect: found
+pattern: 'key="verification"'
+created: 2026-06-02
+last-run: 2026-06-02
+last-result: pass
+---
+
+# EVAL-007: verification signal group is defined
+
+## Scenario
+
+The proficiency-signals research ranks verification (adversarial/clean-context review, TDD, asserts, binary completion criteria) as the single most important 2026 signal — the "biggest unlock" and a top regret-minimizer. The original June 2026 proposal omitted it. It was added as a registered signal group and as an L6 gate requirement.
+
+## Regression path
+
+`measure_ai_proficiency/signals.py` defines a `SignalGroup` with `key="verification"`. Removing it would silently drop the highest-priority signal and break the L6 gate.
+
+## Check
+
+`signals.py` must contain the literal `key="verification"`.
+
+## Pass condition
+
+`grep -qF 'key="verification"' measure_ai_proficiency/signals.py` exits 0.
+
+## Fail condition
+
+The verification signal group has been removed. L6 gating loses its verification requirement and the docs' top signal goes undetected.
+
+## Companion evals
+
+- EVAL-008..011: other 2026 signal groups.
+- EVAL-012: the L6-L8 signal-gate rewire that consumes these signals.

--- a/.evals/cases/EVAL-008.md
+++ b/.evals/cases/EVAL-008.md
@@ -1,0 +1,38 @@
+---
+eval-id: EVAL-008
+source-learning: June 2026 signal enhancement — anti-drift maintenance hygiene (sentinel/canary, audit/detox, steward, decay) added as an L7 gate requirement
+target: measure_ai_proficiency/signals.py
+method: grep-check
+expect: found
+pattern: 'key="maintenance_hygiene"'
+created: 2026-06-02
+last-run: 2026-06-02
+last-result: pass
+---
+
+# EVAL-008: maintenance-hygiene (anti-drift) signal group is defined
+
+## Scenario
+
+The living-context research treats static instruction files as artifacts that rot silently (disk-memory drift). Mature teams add sentinel/canary drift checks, periodic CLAUDE.md/AGENTS.md audits (detox), steward self-healing loops, and decay schedules. This is an L7 gate requirement.
+
+## Regression path
+
+`measure_ai_proficiency/signals.py` defines a `SignalGroup` with `key="maintenance_hygiene"`. Removing it would drop anti-drift detection and break the L7 gate.
+
+## Check
+
+`signals.py` must contain the literal `key="maintenance_hygiene"`.
+
+## Pass condition
+
+`grep -qF 'key="maintenance_hygiene"' measure_ai_proficiency/signals.py` exits 0.
+
+## Fail condition
+
+The maintenance-hygiene signal group has been removed; L7 gating loses its anti-drift requirement.
+
+## Companion evals
+
+- EVAL-007, EVAL-009..011: other 2026 signal groups.
+- EVAL-012: the L6-L8 signal-gate rewire.

--- a/.evals/cases/EVAL-009.md
+++ b/.evals/cases/EVAL-009.md
@@ -1,0 +1,38 @@
+---
+eval-id: EVAL-009
+source-learning: June 2026 signal enhancement — harness engineering captured as a 2026 frontier proxy signal grounded in official harness research (arXiv:2603.28052, arXiv:2605.22166)
+target: measure_ai_proficiency/signals.py
+method: grep-check
+expect: found
+pattern: 'key="harness_engineering"'
+created: 2026-06-02
+last-run: 2026-06-02
+last-result: pass
+---
+
+# EVAL-009: harness-engineering proxy signal group is defined
+
+## Scenario
+
+The 2026 progression Model -> Prompt -> Context -> Harness names harness engineering (the system around the model) as the frontier. Static scans cannot measure runtime harness efficacy, so the scanner detects documented proxies (the keyword framing, feedback loops, worktree isolation).
+
+## Regression path
+
+`measure_ai_proficiency/signals.py` defines a `SignalGroup` with `key="harness_engineering"`. Removing it drops the harness proxy from the harness-orchestration MCP tool and reports.
+
+## Check
+
+`signals.py` must contain the literal `key="harness_engineering"`.
+
+## Pass condition
+
+`grep -qF 'key="harness_engineering"' measure_ai_proficiency/signals.py` exits 0.
+
+## Fail condition
+
+The harness-engineering signal group has been removed.
+
+## Companion evals
+
+- EVAL-007, EVAL-008, EVAL-010, EVAL-011: other 2026 signal groups.
+- EVAL-012: the L6-L8 signal-gate rewire.

--- a/.evals/cases/EVAL-010.md
+++ b/.evals/cases/EVAL-010.md
@@ -1,0 +1,38 @@
+---
+eval-id: EVAL-010
+source-learning: June 2026 signal enhancement — dynamic workflows / orchestration scoped to detectable artifacts (.claude/workflows) as the L8 orchestration gate; grounded in code.claude.com/docs/en/workflows
+target: measure_ai_proficiency/signals.py
+method: grep-check
+expect: found
+pattern: 'key="dynamic_workflows"'
+created: 2026-06-02
+last-run: 2026-06-02
+last-result: pass
+---
+
+# EVAL-010: dynamic-workflows / orchestration signal group is defined
+
+## Scenario
+
+Official Dynamic Workflows (May 28 2026) are a runtime feature; static scans can only detect committed artifacts (a .claude/workflows directory, orchestration scripts) and documented patterns. This signal feeds the L8 orchestration gate and the get_dynamic_workflow_recommendations MCP tool.
+
+## Regression path
+
+`measure_ai_proficiency/signals.py` defines a `SignalGroup` with `key="dynamic_workflows"`. The config also adds `.claude/workflows/` artifacts to Level 8. Removing the signal breaks the L8 orchestration gate.
+
+## Check
+
+`signals.py` must contain the literal `key="dynamic_workflows"`.
+
+## Pass condition
+
+`grep -qF 'key="dynamic_workflows"' measure_ai_proficiency/signals.py` exits 0.
+
+## Fail condition
+
+The dynamic-workflows signal group has been removed; L8 gating loses its orchestration requirement.
+
+## Companion evals
+
+- EVAL-007..009, EVAL-011: other 2026 signal groups.
+- EVAL-012: the L6-L8 signal-gate rewire.

--- a/.evals/cases/EVAL-011.md
+++ b/.evals/cases/EVAL-011.md
@@ -1,0 +1,38 @@
+---
+eval-id: EVAL-011
+source-learning: June 2026 signal enhancement — curricula on-ramps (Anthropic Academy, Google 5-Day AI Agents) as a light content signal grounding levels in official learning paths
+target: measure_ai_proficiency/signals.py
+method: grep-check
+expect: found
+pattern: 'key="curricula"'
+created: 2026-06-02
+last-run: 2026-06-02
+last-result: pass
+---
+
+# EVAL-011: curricula on-ramp signal group is defined
+
+## Scenario
+
+Official free curricula (Anthropic Academy; Google 5-Day AI Agents, whose Day 3 covers Context Engineering) ground the maturity model in real learning paths. Curricula are the weakest per-repo scannable signal, so they carry the lowest weight and are detected as a light content reference.
+
+## Regression path
+
+`measure_ai_proficiency/signals.py` defines a `SignalGroup` with `key="curricula"`. It powers the curricula_alignment MCP tool.
+
+## Check
+
+`signals.py` must contain the literal `key="curricula"`.
+
+## Pass condition
+
+`grep -qF 'key="curricula"' measure_ai_proficiency/signals.py` exits 0.
+
+## Fail condition
+
+The curricula signal group has been removed; curricula_alignment loses its detector.
+
+## Companion evals
+
+- EVAL-007..010: other 2026 signal groups.
+- EVAL-012: the L6-L8 signal-gate rewire.

--- a/.evals/cases/EVAL-012.md
+++ b/.evals/cases/EVAL-012.md
@@ -1,0 +1,37 @@
+---
+eval-id: EVAL-012
+source-learning: June 2026 rewire — Levels 6-8 require 2026 context-engineering signals (not file coverage alone); gates resolved in scanner._compute_signal_gates
+target: measure_ai_proficiency/scanner.py
+method: grep-check
+expect: found
+pattern: "def _compute_signal_gates"
+created: 2026-06-02
+last-run: 2026-06-02
+last-result: pass
+---
+
+# EVAL-012: L6-L8 signal-gate rewire is present
+
+## Scenario
+
+The headline June 2026 change rewires the maturity ladder: reaching L6/L7/L8 now requires the matching context-engineering signals (structured skills + hooks + subagents + verification for L6; eval loops + telemetry + anti-drift for L7; orchestration + plugins + measured outcomes for L8) in addition to file coverage. The gates are resolved by `_compute_signal_gates` and applied in `_calc_level_with_thresholds`.
+
+## Regression path
+
+`measure_ai_proficiency/scanner.py` defines `def _compute_signal_gates` and passes its `gates` into `_calc_level_with_thresholds`. Removing it reverts to file-presence-only leveling, undoing the rewire.
+
+## Check
+
+`scanner.py` must contain the literal `def _compute_signal_gates`.
+
+## Pass condition
+
+`grep -qF 'def _compute_signal_gates' measure_ai_proficiency/scanner.py` exits 0.
+
+## Fail condition
+
+The gating method has been removed; L6-L8 can again be reached on file coverage alone without the required signals.
+
+## Companion evals
+
+- EVAL-007..011: the individual signal groups the gates depend on.

--- a/.evals/cases/EVAL-013.md
+++ b/.evals/cases/EVAL-013.md
@@ -1,0 +1,46 @@
+---
+eval-id: EVAL-013
+source-learning: June 2026 — conciseness/context-hygiene: always-on files (CLAUDE.md/AGENTS.md) should be concise; oversized monolithic files are a permanent context tax and make results worse
+target: measure_ai_proficiency/scanner.py
+method: grep-check
+expect: found
+pattern: "def _analyze_conciseness"
+created: 2026-06-02
+last-run: 2026-06-02
+last-result: pass
+---
+
+# EVAL-013: conciseness / anti-bloat detection for always-on files
+
+## Scenario
+
+The hierarchical/scoped-context research (and the Claude Code memory/best-practices
+docs) establish that always-loaded instruction files are a permanent context tax:
+large monolithic CLAUDE.md/AGENTS.md files degrade results. Mature setups keep a
+thin routing layer and push detail into scoped, on-demand files (skills, "See X.md"
+pointers). The scanner previously only rewarded word count (more = "substance") and
+never penalized bloat — the opposite of the principle.
+
+## Regression path
+
+`measure_ai_proficiency/scanner.py` defines `_analyze_conciseness`, which flags
+always-on files over the (configurable) `word_threshold_bloat` as bloated, emits a
+`BLOAT:` warning, and adds a context-hygiene penalty. On-demand skill bodies are
+exempt (progressive disclosure).
+
+## Check
+
+`scanner.py` must contain the literal `def _analyze_conciseness`.
+
+## Pass condition
+
+`grep -qF 'def _analyze_conciseness' measure_ai_proficiency/scanner.py` exits 0.
+
+## Fail condition
+
+Conciseness detection removed; the tool again rewards length without penalizing
+oversized always-on files.
+
+## Companion evals
+
+- EVAL-007..012: the 2026 signal groups + the L6-L8 gating rewire.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,9 @@ The tool scans repositories for files like `CLAUDE.md`, `.cursorrules`, `.github
 
 **Key Features:**
 - 8-level maturity scoring aligned with Steve Yegge's model
+- **2026 context-engineering signals** (verification, hooks, eval loops, telemetry, anti-drift maintenance hygiene, dynamic-workflow orchestration, plugins, harness engineering, curricula) — grounded in official docs only; see `docs/SIGNALS.md`
+- **L6-L8 are signal-gated**: reaching those levels requires the matching primitives/harness/orchestration signals AND file coverage (not coverage alone)
+- Structural quality scoring of the 6 primitives (skill frontmatter/executable content/verification, hook events, subagents, workflows, plugins)
 - Cross-reference detection between AI instruction files
 - Content quality evaluation (sections, commands, constraints)
 - Multiple output formats (terminal, JSON, markdown, CSV)
@@ -101,6 +104,11 @@ The project now includes an **MCP (Model Context Protocol) server** that makes A
 - `scan_github_repo` - Analyze remote GitHub repo without cloning
 - `scan_github_org` - Analyze entire GitHub organization
 - `validate_file_quality` - Check quality score of specific file
+- `check_harness_orchestration_quality` - 2026 harness/orchestration maturity + L6-L8 signal gates
+- `scan_for_maintenance_hygiene` - Anti-drift maintenance hygiene (sentinel/canary, audit/detox, steward, decay)
+- `get_dynamic_workflow_recommendations` - Adopt Dynamic Workflows + verification (scoped to detectable artifacts)
+- `curricula_alignment` - Official learning on-ramp references (Anthropic Academy, Google 5-Day AI Agents)
+- `cheapest_primitive_decision_tree_report` - Primitive decision discipline (Skill → MCP → Subagent → Hook → Plugin)
 
 **Configuration:** Add to `.mcp.json`:
 ```json
@@ -151,7 +159,8 @@ measure_ai_proficiency/
 ├── __main__.py        # CLI entry point
 ├── mcp_server.py      # MCP server for AI assistant integration
 ├── config.py          # Level definitions and file patterns
-├── scanner.py         # Repository scanning logic + cross-reference detection
+├── signals.py         # 2026 context-engineering signal registry + L6-8 gate requirements (official-doc grounded)
+├── scanner.py         # Repository scanning logic + cross-reference detection + signal analysis + L6-8 gating
 ├── github_scanner.py  # GitHub CLI integration for remote scanning
 ├── reporter.py        # Output formatting (terminal, JSON, markdown, CSV)
 └── repo_config.py     # Repository configuration and tool auto-detection
@@ -214,6 +223,8 @@ pytest tests/ -v
 - Adjust scoring thresholds: Edit `_calculate_overall_level` in `measure_ai_proficiency/scanner.py`
 - Add new cross-reference patterns: Edit `CROSS_REF_PATTERNS` in `measure_ai_proficiency/scanner.py`
 - Add new quality indicators: Edit `QUALITY_PATTERNS` in `measure_ai_proficiency/scanner.py`
+- Add a new 2026 signal: Add a `SignalGroup` to `SIGNAL_GROUPS` in `measure_ai_proficiency/signals.py` (keyword patterns + weight + an **official** reference). To gate a level, add its key to `LEVEL_GATE_REQUIREMENTS` and resolve it in `RepoScanner._compute_signal_gates`. Add a regression eval under `.evals/cases/`. See `docs/SIGNALS.md`.
+- Adjust L6-8 gating: Edit `LEVEL_GATE_REQUIREMENTS` (signals.py) and `_compute_signal_gates` (scanner.py). Levels 6-8 require signals AND file coverage; the `gates` dict flows into `_calc_level_with_thresholds`.
 - Add new MCP tools: Add handler in `measure_ai_proficiency/mcp_server.py`, update `list_tools()` and `call_tool()`
 
 ## Scanning Options

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,7 @@ pytest tests/ -v
 - Add a new 2026 signal: Add a `SignalGroup` to `SIGNAL_GROUPS` in `measure_ai_proficiency/signals.py` (keyword patterns + weight + an **official** reference). To gate a level, add its key to `LEVEL_GATE_REQUIREMENTS` and resolve it in `RepoScanner._compute_signal_gates`. Add a regression eval under `.evals/cases/`. See `docs/SIGNALS.md`.
 - Adjust L6-8 gating: Edit `LEVEL_GATE_REQUIREMENTS` (signals.py) and `_compute_signal_gates` (scanner.py). Levels 6-8 require signals AND file coverage; the `gates` dict flows into `_calc_level_with_thresholds`.
 - Add new MCP tools: Add handler in `measure_ai_proficiency/mcp_server.py`, update `list_tools()` and `call_tool()`
+- Writing/auditing agents files (CLAUDE.md/AGENTS.md): keep them concise and behavioral — every always-loaded line must change behavior or be cut. See `docs/AGENTS_FILE_GUIDANCE.md`.
 
 ## Scanning Options
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Measure context engineering. Look at whether teams are creating files like `CLAU
 
 This tool scans repositories for context engineering artifacts and calculates a maturity score based on an 8-level model aligned with [Steve Yegge's stages](https://steve-yegge.medium.com/welcome-to-gas-town-4f25ee16dd04).
 
-Since v0.6.0 it also detects **2026 context-engineering signals** — verification, hooks, eval loops, telemetry, anti-drift maintenance hygiene, dynamic-workflow orchestration, plugins, and harness engineering — and uses them to **gate Levels 6-8** (file coverage alone is no longer enough). See **[docs/SIGNALS.md](docs/SIGNALS.md)**. All detection is grounded in official documentation.
+Since v0.6.0 it also detects **2026 context-engineering signals** — verification, hooks, eval loops, telemetry, anti-drift maintenance hygiene, dynamic-workflow orchestration, plugins, and harness engineering — and uses them to **gate Levels 6-8** (file coverage alone is no longer enough). It also flags **bloated always-on files** (a permanent context tax). See **[docs/SIGNALS.md](docs/SIGNALS.md)** and **[docs/AGENTS_FILE_GUIDANCE.md](docs/AGENTS_FILE_GUIDANCE.md)** (how to write concise, behavioral CLAUDE.md/AGENTS.md). All detection is grounded in official documentation.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Measure context engineering. Look at whether teams are creating files like `CLAU
 
 This tool scans repositories for context engineering artifacts and calculates a maturity score based on an 8-level model aligned with [Steve Yegge's stages](https://steve-yegge.medium.com/welcome-to-gas-town-4f25ee16dd04).
 
+Since v0.6.0 it also detects **2026 context-engineering signals** — verification, hooks, eval loops, telemetry, anti-drift maintenance hygiene, dynamic-workflow orchestration, plugins, and harness engineering — and uses them to **gate Levels 6-8** (file coverage alone is no longer enough). See **[docs/SIGNALS.md](docs/SIGNALS.md)**. All detection is grounded in official documentation.
+
 ## Quick Start
 
 ```bash
@@ -66,6 +68,11 @@ Ask your AI assistant:
 - `scan_github_repo` - Analyze remote GitHub repo
 - `scan_github_org` - Scan entire GitHub organization
 - `validate_file_quality` - Check specific file quality
+- `check_harness_orchestration_quality` - 2026 harness/orchestration maturity + L6-L8 gates
+- `scan_for_maintenance_hygiene` - Anti-drift maintenance hygiene
+- `get_dynamic_workflow_recommendations` - Adopt Dynamic Workflows + verification
+- `curricula_alignment` - Official learning on-ramp references
+- `cheapest_primitive_decision_tree_report` - Primitive decision discipline
 
 📖 **[Full MCP Documentation](docs/MCP.md)** - Setup, examples, troubleshooting
 

--- a/docs/AGENTS_FILE_GUIDANCE.md
+++ b/docs/AGENTS_FILE_GUIDANCE.md
@@ -1,0 +1,61 @@
+# Writing Effective Agents Files (CLAUDE.md / AGENTS.md)
+
+Short, behavioral, and honest beats long and aspirational. This is the guidance the
+scanner's conciseness checks (`docs/SIGNALS.md`) nudge toward.
+
+## Why conciseness matters
+
+Always-loaded files (`CLAUDE.md`, `AGENTS.md`, copilot-instructions) are a **permanent
+context tax** — every line costs tokens on every turn (even lines the model skips),
+multiplies across multi-agent runs, and pushes compaction earlier. Past a point, **a
+bloated file makes the model ignore your actual instructions**. Anthropic's Claude Code
+memory/best-practices guidance is explicit: keep `CLAUDE.md` focused and human-readable
+(aim for well under ~200 lines).
+
+## The one audit rule
+
+> **Every always-loaded line must change behavior, or cut it.**
+
+For each line, ask: *"What would go wrong if this line wasn't here?"* If the answer is
+"nothing," delete it. Real teams slim files hard this way (e.g. 180 lines → ~24) and get
+better results.
+
+## Avoid aspirational content
+
+Describe how the team **actually works**, not an ideal version of itself. Aspirational
+rules ("always write perfect tests", "follow clean architecture") that aren't enforced
+add noise and erode trust in the file. Document the real conventions, the real gotchas,
+and the things that have actually bitten you.
+
+## Thin core + progressive disclosure
+
+Keep the always-on file a **thin routing layer**; push detail into on-demand surfaces:
+
+- **Skills** (`SKILL.md`) — loaded only when relevant (zero token cost until used).
+- **Scoped files** — `src/auth/CLAUDE.md`, path-scoped rules (nearest scope wins).
+- **Pointers** — "See `docs/TESTING.md` for the test workflow" instead of inlining it.
+
+## Behavioral baseline (Karpathy's LLM-coding pitfalls)
+
+A widely-used, battle-tested concise `CLAUDE.md` distills four behaviors that counter
+common LLM failure modes. They're worth encoding (concisely) in your agents files:
+
+1. **Think before coding** — don't assume silently; surface confusion, tradeoffs, and
+   alternatives; ask when unclear.
+2. **Simplicity first** — minimum code that solves the problem; no speculative
+   abstractions; "if 200 lines could be 50, rewrite it."
+3. **Surgical changes** — touch only what the task requires; don't refactor or reformat
+   adjacent code; only remove dead code your own change created.
+4. **Goal-driven execution** — turn tasks into verifiable success criteria (tests first),
+   then loop until they pass.
+
+These map directly to signals the scanner rewards: constraints/"NEVER do" rules,
+verification discipline, and surgical/minimal-change conventions.
+
+## References (official + exemplar)
+
+- Claude Code memory & best practices — concise, human-readable `CLAUDE.md`:
+  https://docs.claude.com/en/docs/claude-code/memory
+- Agent Skills (progressive disclosure): https://docs.claude.com/en/docs/claude-code/skills
+- Exemplar of a concise, behavioral `CLAUDE.md` (Karpathy-inspired):
+  https://github.com/multica-ai/andrej-karpathy-skills

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -77,7 +77,7 @@ After updating the configuration, restart Claude Code to load the MCP server.
 
 ## Available Tools
 
-The MCP server provides 7 tools for AI proficiency analysis:
+The MCP server provides 12 tools for AI proficiency analysis (7 core + 5 for the 2026 context-engineering signals — see [SIGNALS.md](SIGNALS.md)):
 
 ### 1. `scan_current_repo`
 
@@ -228,6 +228,46 @@ Claude: Your CLAUDE.md scores 7.5/10:
 - Needs work: Only 2 constraints, 150 words (aim for 200+)
 ...
 ```
+
+## 2026 Context-Engineering Signal Tools
+
+These tools surface the [2026 signals](SIGNALS.md) that gate Levels 6-8. All are
+grounded in official documentation; static scans detect documented proxies, not
+runtime efficacy.
+
+### 8. `check_harness_orchestration_quality`
+
+Score harness/orchestration maturity for the current repo.
+
+**Returns:**
+- `structural_quality` — the 6-primitive structural score (skills frontmatter/executable/verification, hooks + events, subagents, workflows, plugins)
+- `harness_signals` — verification, eval loops, telemetry, dynamic workflows, harness engineering, primitive discipline (detected + evidence + official reference)
+- `level_gates` — L6/L7/L8 satisfied status + missing requirements (with how-to + reference)
+- `signal_bonus`
+
+### 9. `scan_for_maintenance_hygiene`
+
+Report anti-drift maintenance hygiene (sentinel/canary, audit/detox, steward loops, decay) plus telemetry.
+
+**Returns:** `maintenance_hygiene_detected`, per-signal evidence, and actionable recommendations grounded in official docs.
+
+### 10. `get_dynamic_workflow_recommendations`
+
+Recommend how to adopt Dynamic Workflows + verification patterns, scoped to what is statically detectable (`.claude/workflows`, orchestration scripts, clean-context verifiers).
+
+**Returns:** `workflows_present`, `dynamic_workflow_signal_detected`, `verification_signal_detected`, the L8 orchestration gate status, the official docs URL, and recommendations.
+
+### 11. `curricula_alignment`
+
+Check whether the repo references official learning on-ramps.
+
+**Returns:** `curricula_referenced`, evidence, and the recommended courses (Anthropic Academy; Google 5-Day AI Agents — Day 3 covers Context Engineering).
+
+### 12. `cheapest_primitive_decision_tree_report`
+
+Return the cheapest-primitive-first decision tree (Skill → MCP → Subagent → Hook → Plugin/Workflow) and which primitives the repo actually uses.
+
+**Returns:** `decision_tree`, `rule`, `primitives_present`, and the decision-discipline signal.
 
 ## Usage Examples
 

--- a/docs/SIGNALS.md
+++ b/docs/SIGNALS.md
@@ -82,6 +82,11 @@ tool nudges toward: keep a thin routing layer in the floor file and push detail 
 scoped/on-demand files (skills, "See X.md" pointers). Grounded in the Claude Code
 memory/best-practices guidance to keep `CLAUDE.md` concise and human-readable.
 
+The audit rule the bloat recommendation teaches: **every always-loaded line must change
+behavior, or cut it** — ask *"what would go wrong if this line wasn't here?"*. Full
+write-up (including the Karpathy behavioral principles) in
+[AGENTS_FILE_GUIDANCE.md](AGENTS_FILE_GUIDANCE.md).
+
 ## Signal bonus
 
 Matched signals plus structural quality contribute a **bounded bonus (0-10)** to

--- a/docs/SIGNALS.md
+++ b/docs/SIGNALS.md
@@ -69,6 +69,19 @@ drops accordingly via the per-level minimum scores). The reports and the
 `get_recommendations` output explain exactly which signals are missing, with an
 official-docs link for each.
 
+## Conciseness / context-hygiene (anti-bloat)
+
+Always-loaded "floor" files (`CLAUDE.md`, `AGENTS.md`, copilot-instructions) are a
+**permanent context tax** — large monolithic files degrade results and crowd out
+working context. The scanner flags an always-on file as **bloated** when it exceeds
+`word_threshold_bloat` (default **1500 words**, configurable in `.ai-proficiency.yaml`
+under `quality:`), emits a `BLOAT:` warning, and applies a small validation penalty
+(up to 3 pts, scaled by overage). On-demand **skill bodies are exempt** — progressive
+disclosure means they cost nothing until invoked, so length there is fine. The fix the
+tool nudges toward: keep a thin routing layer in the floor file and push detail into
+scoped/on-demand files (skills, "See X.md" pointers). Grounded in the Claude Code
+memory/best-practices guidance to keep `CLAUDE.md` concise and human-readable.
+
 ## Signal bonus
 
 Matched signals plus structural quality contribute a **bounded bonus (0-10)** to

--- a/docs/SIGNALS.md
+++ b/docs/SIGNALS.md
@@ -1,0 +1,95 @@
+# 2026 Context-Engineering Signals
+
+`measure-ai-proficiency` (v0.6.0+) goes beyond file *presence* and detects the
+context-engineering **signals** that distinguish production-grade agent setups in
+2026: structural primitive quality, verification, deterministic hooks, eval loops,
+telemetry, anti-drift maintenance hygiene, dynamic-workflow orchestration, plugin
+distribution, harness engineering, and curricula on-ramps.
+
+These signals **rewire Levels 6-8**: reaching those levels now requires the
+matching signals *and* file coverage — not file coverage alone.
+
+> **Grounding.** Every signal is grounded only in official documentation and
+> primary sources (Claude Code docs, the Dynamic Workflows docs, the harness
+> research papers, Anthropic Academy, and the Google 5-Day AI Agents course).
+> Detection patterns never reference social-media handles.
+>
+> **Limitation.** Static scans cannot measure *runtime* efficacy. These signals
+> detect documented **proxies** in committed artifacts (keywords + filesystem
+> structure), not whether dynamic workflows or eval loops actually run.
+
+## Signal groups
+
+Defined in [`measure_ai_proficiency/signals.py`](../measure_ai_proficiency/signals.py).
+
+| Key | Category | What it detects | Official reference |
+|-----|----------|-----------------|--------------------|
+| `verification` | harness | Adversarial/clean-context review, TDD, asserts, binary completion criteria | docs.claude.com/.../hooks; arXiv:2603.28052 |
+| `hooks` | primitive | Deterministic PreToolUse/PostToolUse/SessionStart/Stop/SubagentStop guardrails | docs.claude.com/.../hooks |
+| `primitive_discipline` | primitive | Cheapest-primitive-first decisions, progressive disclosure | docs.claude.com/.../skills; agentskills.io |
+| `eval_loops` | harness | Eval cases, regression suites, held-out/golden/benchmark gates | docs.claude.com; arXiv:2605.22166 |
+| `telemetry` | harness | Telemetry, scorecards, tracing, drift incidents, audit logs | docs.claude.com; arXiv:2603.28052 |
+| `maintenance_hygiene` | maintenance | Sentinel/canary drift checks, audit/detox, steward loops, decay | docs.claude.com/.../memory |
+| `dynamic_workflows` | orchestration | Dynamic workflows, orchestration scripts, parallel subagents, resumability | code.claude.com/docs/en/workflows |
+| `plugins` | primitive | Plugin/marketplace manifests bundling primitives for teams | docs.claude.com/.../plugins |
+| `harness_engineering` | harness | The system-around-the-model framing, feedback loops, worktree isolation | arXiv:2603.28052; arXiv:2605.22166 |
+| `curricula` | curricula | Anthropic Academy / Google 5-Day AI Agents references | anthropic.com/learn; Google 5-Day AI Agents |
+
+## Structural quality
+
+Beyond keywords, the scanner inspects the **6 primitives** structurally
+(`StructuralQuality`):
+
+- **Skills** — count, YAML frontmatter, executable/data content (non-`.md` files
+  in the skill folder), and in-skill verification language.
+- **Hooks** — `.claude/hooks/` contents and `hooks` config / lifecycle events in
+  `.claude/settings.json`.
+- **Subagents** — agent definition files under `.claude/agents`, `.github/agents`, `agents/`.
+- **Workflows** — a non-empty `.claude/workflows/` directory.
+- **Plugins** — `.claude-plugin/` (or nested) manifests.
+
+These roll up into a 0-10 `structural_score`.
+
+## The L6-L8 rewire (gating)
+
+`LEVEL_GATE_REQUIREMENTS` (in `signals.py`) defines what each upper level needs.
+The scanner resolves them in `_compute_signal_gates` and applies them in
+`_calc_level_with_thresholds`. The ladder is monotonic, so requirements are
+cumulative — you cannot skip a gate.
+
+| Level | Requires (in addition to file coverage) |
+|-------|------------------------------------------|
+| **L6** | structured skills **+** hooks **+** subagents **+** verification |
+| **L7** | L6 **+** eval loops **+** telemetry **+** anti-drift maintenance hygiene |
+| **L8** | L7 **+** orchestration (`.claude/workflows`) **+** plugins **+** measured outcomes |
+
+If file coverage would place a repo at L8 but the signal gates are not met, the
+achieved level is capped at the highest fully-satisfied level (and the score
+drops accordingly via the per-level minimum scores). The reports and the
+`get_recommendations` output explain exactly which signals are missing, with an
+official-docs link for each.
+
+## Signal bonus
+
+Matched signals plus structural quality contribute a **bounded bonus (0-10)** to
+`overall_score`, added alongside the cross-reference bonus and clamped at 100.
+Gating affects the *level*; the bonus affects the *score within a level*.
+
+## Where signals surface
+
+- **Terminal / Markdown reports** — a "Context Engineering Signals (2026)" section
+  with per-signal status, structural quality, and L6-L8 gate status.
+- **JSON / CSV** — a `signals` block (JSON) and `signal_bonus`,
+  `structural_score`, `matched_signal_count`, `l6_gate`, `l7_gate`, `l8_gate`
+  columns (CSV).
+- **MCP tools** — `check_harness_orchestration_quality`,
+  `scan_for_maintenance_hygiene`, `get_dynamic_workflow_recommendations`,
+  `curricula_alignment`, `cheapest_primitive_decision_tree_report`, and the
+  existing `scan_current_repo` / `get_recommendations` (see [MCP.md](MCP.md)).
+
+## Extending the signals
+
+Add a new `SignalGroup` to `SIGNAL_GROUPS` in `signals.py` (keyword patterns +
+weight + an **official** reference). To make it gate a level, add its key to
+`LEVEL_GATE_REQUIREMENTS` and resolve it in `RepoScanner._compute_signal_gates`.
+Add a regression eval under `.evals/cases/` so the signal can't be silently removed.

--- a/measure_ai_proficiency/__init__.py
+++ b/measure_ai_proficiency/__init__.py
@@ -17,7 +17,7 @@ Supports:
 - Tool-specific recommendations
 """
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 __author__ = "Peter Skoett"
 
 from .scanner import (
@@ -28,7 +28,11 @@ from .scanner import (
     CrossReference,
     ContentQuality,
     CrossReferenceResult,
+    HarnessSignals,
+    SignalHit,
+    StructuralQuality,
 )
+from .signals import SignalGroup, SIGNAL_GROUPS, LEVEL_GATE_REQUIREMENTS
 from .reporter import (
     TerminalReporter,
     JsonReporter,
@@ -53,6 +57,12 @@ __all__ = [
     "CrossReference",
     "ContentQuality",
     "CrossReferenceResult",
+    "HarnessSignals",
+    "SignalHit",
+    "StructuralQuality",
+    "SignalGroup",
+    "SIGNAL_GROUPS",
+    "LEVEL_GATE_REQUIREMENTS",
     "TerminalReporter",
     "JsonReporter",
     "MarkdownReporter",

--- a/measure_ai_proficiency/config.py
+++ b/measure_ai_proficiency/config.py
@@ -327,9 +327,14 @@ LEVEL_5_PATTERNS = LevelConfig(
 )
 
 # Level 6: Fleet Infrastructure (Yegge Stage 6)
+# 2026 gate: full primitive coverage (structured skills + hooks + subagents)
+# plus verification discipline is REQUIRED to reach this level (see scanner gating).
 LEVEL_6_PATTERNS = LevelConfig(
     name="Level 6: Fleet Infrastructure",
-    description="Advanced memory systems, shared context, and workflow pipelines",
+    description=(
+        "Full primitive coverage — structured skills, deterministic hooks, and "
+        "subagents — plus verification discipline, advanced memory, and shared context"
+    ),
     file_patterns=[
         # Beads memory system
         ".beads/*.md",
@@ -406,9 +411,14 @@ LEVEL_6_PATTERNS = LevelConfig(
 )
 
 # Level 7: Agent Fleet (Yegge Stage 7)
+# 2026 gate: advanced harness — eval/verification loops + telemetry/observability +
+# anti-drift maintenance hygiene — is REQUIRED to reach this level (see scanner gating).
 LEVEL_7_PATTERNS = LevelConfig(
     name="Level 7: Agent Fleet",
-    description="Large agent fleet with governance, scheduling, and multi-agent pipelines",
+    description=(
+        "Advanced harness — eval/verification loops, telemetry/observability, and "
+        "anti-drift maintenance — over a multi-agent fleet with governance and pipelines"
+    ),
     file_patterns=[
         # Governance
         "GOVERNANCE.md",
@@ -471,6 +481,32 @@ LEVEL_7_PATTERNS = LevelConfig(
         ".metrics/agents/*.json",
         ".metrics/agents/*.yaml",
         "metrics/agents/*.md",
+
+        # Verification & eval harness (2026: docs.claude.com hooks/skills, eval loops)
+        ".evals/*.md",
+        ".evals/cases/*.md",
+        ".evals/EVAL_INDEX.md",
+        "evals/*.md",
+        "evals/cases/*.md",
+        "VERIFICATION.md",
+        "EVALS.md",
+        "EVAL.md",
+        "docs/EVALS.md",
+        "agents/VERIFICATION.md",
+
+        # Telemetry & observability (2026: harness engineering signal)
+        "TELEMETRY.md",
+        "OBSERVABILITY.md",
+        "agents/TELEMETRY.md",
+        "agents/OBSERVABILITY.md",
+        "SCORECARD.md",
+        "agents/SCORECARD.md",
+
+        # Anti-drift / maintenance hygiene (2026: living-context practice)
+        "DRIFT.md",
+        "MAINTENANCE.md",
+        "agents/MAINTENANCE.md",
+        "DREAMS.md",
     ],
     directory_patterns=[
         "agents/specialists",
@@ -488,14 +524,22 @@ LEVEL_7_PATTERNS = LevelConfig(
         ".metrics/agents",
         "metrics/agents",
         "pipelines/multi_agent",
+        ".evals",
+        ".evals/cases",
+        "evals",
     ],
     weight=4.0
 )
 
 # Level 8: Custom Orchestration (Yegge Stage 8)
+# 2026 gate: production orchestration ecosystem — dynamic workflows / orchestration
+# scripts + plugin distribution + measured outcomes — is REQUIRED (see scanner gating).
 LEVEL_8_PATTERNS = LevelConfig(
     name="Level 8: Custom Orchestration",
-    description="Custom orchestration, meta-automation, and frontier tooling",
+    description=(
+        "Production orchestration ecosystem — dynamic workflows / external orchestration "
+        "scripts, plugin distribution, and measured outcomes — at the frontier"
+    ),
     file_patterns=[
         # Custom orchestration
         "orchestration.yaml",
@@ -571,6 +615,23 @@ LEVEL_8_PATTERNS = LevelConfig(
         "infra/agents/*.tf",
         "infra/agents/*.yaml",
         "k8s/agents/*.yaml",
+
+        # Dynamic workflows / orchestration scripts
+        # (2026: official Dynamic Workflows — code.claude.com/docs/en/workflows)
+        ".claude/workflows/*.md",
+        ".claude/workflows/*.js",
+        ".claude/workflows/*.ts",
+        ".claude/workflows/*.json",
+        ".claude/workflows/*.py",
+        "workflows/scripts/*.js",
+        "ORCHESTRATION_SCRIPT.md",
+
+        # Plugin distribution (2026: docs.claude.com/.../plugins)
+        ".claude-plugin/plugin.json",
+        ".claude-plugin/marketplace.json",
+        ".claude/plugins/*/plugin.json",
+        ".claude/plugins/*/.claude-plugin/plugin.json",
+        "plugins/*/.claude-plugin/plugin.json",
     ],
     directory_patterns=[
         "orchestration",
@@ -588,6 +649,9 @@ LEVEL_8_PATTERNS = LevelConfig(
         "watchdog",
         "infra/agents",
         "k8s/agents",
+        ".claude/workflows",
+        ".claude-plugin",
+        ".claude/plugins",
     ],
     weight=5.0
 )

--- a/measure_ai_proficiency/github_scanner.py
+++ b/measure_ai_proficiency/github_scanner.py
@@ -218,7 +218,15 @@ def get_repo_tree(owner: str, repo: str, branch: str = "main") -> List[Dict[str,
         check=True  # Raise CalledProcessError on non-zero exit
     )
 
-    data = json.loads(result.stdout)
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        # A non-JSON response (HTML error page, truncated body) is treated as a
+        # subprocess failure so the retry decorator can back off and retry.
+        raise subprocess.CalledProcessError(
+            1, ["gh", "api", f"repos/{owner}/{repo}/git/trees/{branch}"],
+            output=result.stdout, stderr=f"Invalid JSON from GitHub API: {e}"
+        )
     tree = data.get("tree", [])
 
     # Filter for files only (not directories) and exclude large files
@@ -248,7 +256,9 @@ def get_relevant_files(tree: List[Dict[str, Any]]) -> List[str]:
     always_check = {
         "CLAUDE.md", "AGENTS.md", ".cursorrules", "CODEX.md",
         ".github/copilot-instructions.md", ".copilot-instructions.md",
-        ".ai-proficiency.yaml", ".ai-proficiency.yml"
+        ".ai-proficiency.yaml", ".ai-proficiency.yml",
+        # Hook configuration (2026 signal detection)
+        ".claude/settings.json", ".claude/settings.local.json",
     }
 
     # Patterns that need special handling
@@ -261,12 +271,29 @@ def get_relevant_files(tree: List[Dict[str, Any]]) -> List[str]:
         ".claude/commands/", ".github/commands/"
     ]
 
+    # 2026 artifact directories: pull any file under these prefixes so signal
+    # detection (workflows, hooks, plugins, eval loops) works on remote scans.
+    artifact_prefixes = [
+        ".claude/workflows/", ".claude/hooks/", ".claude/plugins/",
+        ".claude-plugin/", ".evals/", "evals/",
+    ]
+
     for entry in tree:
         path = entry.get("path", "")
 
         # Check always_check files
         if path in always_check:
             relevant_paths.append(path)
+            continue
+
+        # Check 2026 artifact directories (any file underneath)
+        matched_artifact = False
+        for prefix in artifact_prefixes:
+            if path.startswith(prefix):
+                relevant_paths.append(path)
+                matched_artifact = True
+                break
+        if matched_artifact:
             continue
 
         # Check if in skills directory
@@ -314,8 +341,14 @@ def download_repo_files(owner: str, repo: str, branch: str, target_dir: Path) ->
         for file_path in relevant_files:
             content = fetch_file_from_github(owner, repo, file_path, branch)
             if content is not None:
-                # Create directory structure
-                full_path = target_dir / file_path
+                # Resolve and verify the path stays inside target_dir — defends
+                # against path traversal if the API returns adversarial paths
+                # (e.g. "../../etc/passwd").
+                target_root = target_dir.resolve()
+                full_path = (target_dir / file_path).resolve()
+                if not (full_path == target_root or target_root in full_path.parents):
+                    print(f"Warning: Skipping path outside target dir: {file_path}", file=sys.stderr)
+                    continue
                 full_path.parent.mkdir(parents=True, exist_ok=True)
 
                 # Write file

--- a/measure_ai_proficiency/mcp_server.py
+++ b/measure_ai_proficiency/mcp_server.py
@@ -24,6 +24,7 @@ from .scanner import RepoScanner, scan_multiple_repos
 from .github_scanner import scan_github_repo, scan_github_org
 from .reporter import JsonReporter
 from .config import LEVELS
+from .signals import GATE_REQUIREMENT_LABELS, GATE_REQUIREMENT_REFERENCES
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -182,6 +183,51 @@ async def list_tools() -> list[Tool]:
                 "required": ["file_path"],
             },
         ),
+        Tool(
+            name="check_harness_orchestration_quality",
+            description="Score 2026 harness/orchestration maturity for the current repo: structural quality of the 6 primitives, dynamic-workflow and harness signals, and the L6-L8 signal gates (what's required to reach each level).",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        ),
+        Tool(
+            name="scan_for_maintenance_hygiene",
+            description="Report anti-drift maintenance hygiene for the current repo: sentinel/canary drift checks, audits/detox, steward loops, decay schedules, plus telemetry signals. Grounded in official docs.",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        ),
+        Tool(
+            name="get_dynamic_workflow_recommendations",
+            description="Recommend how to adopt Dynamic Workflows + verification patterns for the current repo, scoped to what is statically detectable (.claude/workflows, orchestration scripts, clean-context verifiers). Cites official workflow docs.",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        ),
+        Tool(
+            name="curricula_alignment",
+            description="Check whether the current repo references official learning on-ramps (Anthropic Academy, Google 5-Day AI Agents course) that teach context engineering and production agent patterns.",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        ),
+        Tool(
+            name="cheapest_primitive_decision_tree_report",
+            description="Return the cheapest-primitive-first decision tree (Skill -> MCP -> Subagent -> Hook -> escalate) and report which primitives the current repo actually uses, with decision-discipline signals.",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        ),
     ]
 
 
@@ -214,6 +260,16 @@ async def call_tool(name: str, arguments: Any) -> list[TextContent]:
             if not file_path:
                 raise ValueError("file_path parameter is required")
             return await validate_file_quality_handler(file_path)
+        elif name == "check_harness_orchestration_quality":
+            return await check_harness_orchestration_quality_handler()
+        elif name == "scan_for_maintenance_hygiene":
+            return await scan_for_maintenance_hygiene_handler()
+        elif name == "get_dynamic_workflow_recommendations":
+            return await get_dynamic_workflow_recommendations_handler()
+        elif name == "curricula_alignment":
+            return await curricula_alignment_handler()
+        elif name == "cheapest_primitive_decision_tree_report":
+            return await cheapest_primitive_decision_tree_report_handler()
         else:
             raise ValueError(f"Unknown tool: {name}")
     except Exception as e:
@@ -352,10 +408,30 @@ async def scan_github_repo_handler(repo: str) -> list[TextContent]:
             }, indent=2)
         )]
 
+    def _fetch_scan_cleanup() -> Optional[Dict[str, Any]]:
+        # github_scanner.scan_github_repo returns a temp dir Path (or None);
+        # wrap it with RepoScanner to produce a RepoScore, then clean up.
+        temp_dir = scan_github_repo(repo)
+        if temp_dir is None:
+            return None
+        try:
+            score = RepoScanner(str(temp_dir)).scan()
+            score.repo_path = repo
+            return format_score_result(score)
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
     try:
-        # Run blocking GitHub scan in thread pool to avoid blocking the event loop
-        score = await asyncio.to_thread(scan_github_repo, repo)
-        result = format_score_result(score)
+        # Run blocking fetch + scan + cleanup in a thread to avoid blocking the loop
+        result = await asyncio.to_thread(_fetch_scan_cleanup)
+        if result is None:
+            return [TextContent(
+                type="text",
+                text=json.dumps({
+                    "error": "Failed to fetch repository (not found, no AI files, or access denied)",
+                    "repo": repo,
+                }, indent=2)
+            )]
 
         return [TextContent(
             type="text",
@@ -385,14 +461,26 @@ async def scan_github_org_handler(org: str, limit: Optional[int]) -> list[TextCo
             }, indent=2)
         )]
 
-    try:
-        # Run blocking GitHub scan in thread pool to avoid blocking the event loop
-        scores = await asyncio.to_thread(scan_github_org, org, limit)
+    def _fetch_scan_cleanup_org() -> List[Dict[str, Any]]:
+        # github_scanner.scan_github_org returns List[(repo_name, temp_dir|None)];
+        # wrap each temp dir with RepoScanner, then clean up. NOTE: limit is a
+        # keyword arg (the function signature is (org, verbose, limit)).
+        repos = scan_github_org(org, limit=limit) if limit else scan_github_org(org)
+        out: List[Dict[str, Any]] = []
+        for repo_name, temp_dir in repos:
+            if temp_dir is None:
+                continue
+            try:
+                score = RepoScanner(str(temp_dir)).scan()
+                score.repo_path = repo_name
+                out.append(format_score_result(score))
+            finally:
+                shutil.rmtree(temp_dir, ignore_errors=True)
+        return out
 
-        # Format all scores
-        results = []
-        for score in scores:
-            results.append(format_score_result(score))
+    try:
+        # Run blocking fetch + scan + cleanup in a thread to avoid blocking the loop
+        results = await asyncio.to_thread(_fetch_scan_cleanup_org)
 
         summary = {
             "organization": org,
@@ -491,6 +579,246 @@ async def validate_file_quality_handler(file_path: str) -> list[TextContent]:
         type="text",
         text=json.dumps(result, indent=2)
     )]
+
+
+# =============================================================================
+# 2026 Context-Engineering Signal Tool Handlers
+# =============================================================================
+
+async def _scan_current_for_signals():
+    """Scan the current repo and return its RepoScore (with signals computed)."""
+    repo_path = get_current_repo()
+    scanner = RepoScanner(repo_path)
+    return await asyncio.to_thread(scanner.scan)
+
+
+def _missing_gate_detail(signals, level: int) -> List[Dict[str, str]]:
+    """Build actionable detail for a level's missing gate requirements."""
+    return [
+        {
+            "requirement": req,
+            "how": GATE_REQUIREMENT_LABELS.get(req, req),
+            "reference": GATE_REQUIREMENT_REFERENCES.get(req, ""),
+        }
+        for req in signals.gate_missing.get(level, [])
+    ]
+
+
+async def check_harness_orchestration_quality_handler() -> list[TextContent]:
+    """Score harness/orchestration maturity for the current repo."""
+    score = await _scan_current_for_signals()
+    sig = score.signals
+    if not sig:
+        return [TextContent(type="text", text=json.dumps(
+            {"error": "No signals computed for this repository"}, indent=2))]
+
+    harness_categories = {"harness", "orchestration", "primitive"}
+    result: Dict[str, Any] = {
+        "repo_name": score.repo_name,
+        "overall_level": score.overall_level,
+        "overall_score": round(score.overall_score, 1),
+        "signal_bonus": round(sig.bonus_points, 2),
+        "structural_quality": None,
+        "harness_signals": {
+            key: {
+                "title": h.title,
+                "category": h.category,
+                "detected": h.matched,
+                "evidence": h.evidence,
+                "official_reference": h.official_reference,
+            }
+            for key, h in sig.hits.items()
+            if h.category in harness_categories
+        },
+        "level_gates": {
+            f"L{lvl}": {
+                "satisfied": sig.gates.get(lvl, False),
+                "missing": _missing_gate_detail(sig, lvl),
+            }
+            for lvl in (6, 7, 8)
+        },
+        "note": "Static scans detect documented proxies (artifacts/keywords), not runtime efficacy.",
+    }
+    if sig.structural:
+        sq = sig.structural
+        result["structural_quality"] = {
+            "structural_score": round(sq.structural_score, 2),
+            "skills_count": sq.skills_count,
+            "skills_structured": sq.skills_structured,
+            "skills_with_frontmatter": sq.skills_with_frontmatter,
+            "skills_with_executable_content": sq.skills_with_executable_content,
+            "skills_with_verification": sq.skills_with_verification,
+            "hooks_present": sq.hooks_present,
+            "hook_events": sq.hook_events,
+            "subagents_count": sq.subagents_count,
+            "workflows_present": sq.workflows_present,
+            "plugins_present": sq.plugins_present,
+        }
+    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+
+async def scan_for_maintenance_hygiene_handler() -> list[TextContent]:
+    """Report anti-drift maintenance hygiene for the current repo."""
+    score = await _scan_current_for_signals()
+    sig = score.signals
+    keys = ("maintenance_hygiene", "telemetry", "verification")
+    hits = {k: sig.hits[k] for k in keys if k in sig.hits} if sig else {}
+
+    hygiene = hits.get("maintenance_hygiene")
+    telemetry = hits.get("telemetry")
+    recommendations: List[str] = []
+    if not (hygiene and hygiene.matched):
+        recommendations.append(
+            "Add anti-drift sentinels/canaries and a periodic CLAUDE.md/AGENTS.md audit (detox). "
+            "See https://docs.claude.com/en/docs/claude-code/memory"
+        )
+    if not (telemetry and telemetry.matched):
+        recommendations.append(
+            "Add telemetry/observability (metrics, scorecards, drift incidents) to measure harness health."
+        )
+
+    result = {
+        "repo_name": score.repo_name,
+        "maintenance_hygiene_detected": bool(hygiene and hygiene.matched),
+        "signals": {
+            k: {
+                "detected": h.matched,
+                "evidence": h.evidence,
+                "official_reference": h.official_reference,
+            }
+            for k, h in hits.items()
+        },
+        "recommendations": recommendations or ["Maintenance hygiene signals already present."],
+    }
+    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+
+async def get_dynamic_workflow_recommendations_handler() -> list[TextContent]:
+    """Recommend Dynamic Workflows + verification adoption for the current repo."""
+    score = await _scan_current_for_signals()
+    sig = score.signals
+    sq = sig.structural if sig else None
+    dw = sig.hits.get("dynamic_workflows") if sig else None
+    verif = sig.hits.get("verification") if sig else None
+
+    workflows_present = bool(sq and sq.workflows_present)
+    dw_detected = bool(dw and dw.matched)
+    verif_detected = bool(verif and verif.matched)
+
+    recommendations: List[str] = []
+    if not workflows_present:
+        recommendations.append(
+            "Add a .claude/workflows/ directory with reusable orchestration scripts "
+            "(save a proven workflow as a project slash command). "
+            "See https://code.claude.com/docs/en/workflows"
+        )
+    if not dw_detected:
+        recommendations.append(
+            "Document dynamic-workflow patterns: plan -> orchestration script -> parallel "
+            "subagents -> converge, with resumable background execution for large migrations/audits."
+        )
+    if not verif_detected:
+        recommendations.append(
+            "Add clean-context verification workers / adversarial refutation so verifiers do not "
+            "assume the work was correct. See https://docs.claude.com/en/docs/claude-code/hooks"
+        )
+
+    result = {
+        "repo_name": score.repo_name,
+        "workflows_present": workflows_present,
+        "dynamic_workflow_signal_detected": dw_detected,
+        "verification_signal_detected": verif_detected,
+        "l8_orchestration_gate": {
+            "satisfied": sig.gates.get(8, False) if sig else False,
+            "missing": _missing_gate_detail(sig, 8) if sig else [],
+        },
+        "official_docs": "https://code.claude.com/docs/en/workflows",
+        "recommendations": recommendations or [
+            "Strong: dynamic-workflow and verification signals already present."
+        ],
+        "note": "Static scans detect committed artifacts (.claude/workflows, orchestration "
+                "scripts), not runtime workflow execution.",
+    }
+    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+
+async def curricula_alignment_handler() -> list[TextContent]:
+    """Check curricula on-ramp references in the current repo."""
+    score = await _scan_current_for_signals()
+    sig = score.signals
+    cur = sig.hits.get("curricula") if sig else None
+    referenced = bool(cur and cur.matched)
+
+    result = {
+        "repo_name": score.repo_name,
+        "curricula_referenced": referenced,
+        "evidence": cur.evidence if cur else [],
+        "recommended_courses": [
+            {
+                "name": "Anthropic Academy — Claude Code, Agent Skills, MCP, workflows",
+                "reference": "https://www.anthropic.com/learn",
+            },
+            {
+                "name": "Google 5-Day AI Agents course — Day 3 covers Context Engineering",
+                "reference": "Google 5-Day AI Agents course",
+            },
+        ],
+        "recommendation": (
+            "Curricula on-ramps referenced — good team baseline."
+            if referenced
+            else "Reference official on-ramps (Anthropic Academy, Google 5-Day AI Agents) in your "
+                 "context docs to ground the team in context engineering + production patterns."
+        ),
+    }
+    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+
+async def cheapest_primitive_decision_tree_report_handler() -> list[TextContent]:
+    """Return the cheapest-primitive-first decision tree + repo primitive usage."""
+    score = await _scan_current_for_signals()
+    sig = score.signals
+    sq = sig.structural if sig else None
+    discipline = sig.hits.get("primitive_discipline") if sig else None
+
+    decision_tree = [
+        {"step": 1, "primitive": "Skill",
+         "question": "Does the agent need knowledge or a repeatable procedure?",
+         "reference": "https://docs.claude.com/en/docs/claude-code/skills"},
+        {"step": 2, "primitive": "MCP",
+         "question": "Does it need to reach an external system (data/actions)?",
+         "reference": "https://modelcontextprotocol.io"},
+        {"step": 3, "primitive": "Subagent",
+         "question": "Does a side task need its own isolated context window?",
+         "reference": "https://docs.claude.com/en/docs/claude-code/sub-agents"},
+        {"step": 4, "primitive": "Hook",
+         "question": "Must a behavior be enforced deterministically every time?",
+         "reference": "https://docs.claude.com/en/docs/claude-code/hooks"},
+        {"step": 5, "primitive": "Plugin / Workflow",
+         "question": "Distribute to a team or orchestrate at scale?",
+         "reference": "https://docs.claude.com/en/docs/claude-code/plugins"},
+    ]
+
+    primitives_present = {
+        "skills": bool(sq and sq.skills_count > 0),
+        "hooks": bool(sq and sq.hooks_present),
+        "subagents": bool(sq and sq.subagents_count > 0),
+        "workflows": bool(sq and sq.workflows_present),
+        "plugins": bool(sq and sq.plugins_present),
+    }
+
+    result = {
+        "repo_name": score.repo_name,
+        "rule": "Reach for the cheapest primitive first; escalate only when a failure "
+                "mode or scale justifies it.",
+        "decision_tree": decision_tree,
+        "primitives_present": primitives_present,
+        "decision_discipline_signal": {
+            "detected": bool(discipline and discipline.matched),
+            "evidence": discipline.evidence if discipline else [],
+        },
+        "progressive_disclosure_reference": "https://docs.claude.com/en/docs/claude-code/skills",
+    }
+    return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
 
 # =============================================================================

--- a/measure_ai_proficiency/repo_config.py
+++ b/measure_ai_proficiency/repo_config.py
@@ -46,6 +46,7 @@ class RepoConfig:
     min_substantive_bytes: int = 100  # Minimum bytes for a file to be "substantive"
     word_threshold_partial: int = 50  # Words for partial quality points
     word_threshold_full: int = 200  # Words for full quality points
+    word_threshold_bloat: int = 1500  # Words above which an always-on file is "bloated"
     git_timeout: int = 5  # Git command timeout in seconds
 
     # Whether config was loaded from file
@@ -210,6 +211,8 @@ def load_repo_config(repo_path: Path) -> RepoConfig:
                     config.word_threshold_partial = int(quality["word_threshold_partial"])
                 if "word_threshold_full" in quality:
                     config.word_threshold_full = int(quality["word_threshold_full"])
+                if "word_threshold_bloat" in quality:
+                    config.word_threshold_bloat = int(quality["word_threshold_bloat"])
                 if "git_timeout" in quality:
                     config.git_timeout = int(quality["git_timeout"])
 

--- a/measure_ai_proficiency/reporter.py
+++ b/measure_ai_proficiency/reporter.py
@@ -385,6 +385,49 @@ class TerminalReporter:
 
                 print(file=output)
 
+        # 2026 context-engineering signals
+        if score.signals:
+            sig = score.signals
+            print(_color("  Context Engineering Signals (2026):", Colors.BOLD), file=output)
+            print(file=output)
+
+            if sig.structural:
+                sq = sig.structural
+                print(
+                    f"    Structural quality: {sq.structural_score:.1f}/10  "
+                    f"(skills:{sq.skills_count} hooks:{'yes' if sq.hooks_present else 'no'} "
+                    f"subagents:{sq.subagents_count} workflows:{'yes' if sq.workflows_present else 'no'} "
+                    f"plugins:{'yes' if sq.plugins_present else 'no'})",
+                    file=output,
+                )
+                print(file=output)
+
+            for key, h in sig.hits.items():
+                status = "✓" if h.matched else "○"
+                status_color = Colors.GREEN if h.matched else Colors.DIM
+                evidence = ""
+                if h.matched and h.evidence:
+                    evidence = _color(" — " + ", ".join(h.evidence[:3]), Colors.DIM)
+                print(f"    {_color(status, status_color)} {h.title}{evidence}", file=output)
+
+            print(file=output)
+            for lvl in (6, 7, 8):
+                if lvl not in sig.gates:
+                    continue
+                ok = sig.gates[lvl]
+                gstat = "✓" if ok else "○"
+                gcolor = Colors.GREEN if ok else Colors.DIM
+                if ok:
+                    print(f"    {_color(gstat, gcolor)} L{lvl} signal gate satisfied", file=output)
+                else:
+                    missing = ", ".join(sig.gate_missing.get(lvl, []))
+                    print(f"    {_color(gstat, gcolor)} L{lvl} signal gate: missing {missing}", file=output)
+
+            if sig.bonus_points > 0:
+                print(file=output)
+                print(f"    {_color(f'Signal Bonus: +{sig.bonus_points:.1f}', Colors.CYAN)}", file=output)
+            print(file=output)
+
         # Recommendations
         if score.recommendations:
             print(_color("  Recommendations:", Colors.BOLD), file=output)
@@ -656,6 +699,42 @@ class JsonReporter:
                         "indicators": b.outcomes.indicators,
                     }
 
+        # Add 2026 context-engineering signals if present (also consumed by MCP)
+        if score.signals:
+            sig = score.signals
+            result["signals"] = {
+                "bonus_points": round(sig.bonus_points, 2),
+                "matched": sig.matched_keys,
+                "gates": {str(k): v for k, v in sig.gates.items()},
+                "gate_missing": {str(k): list(v) for k, v in sig.gate_missing.items()},
+                "warnings": sig.warnings,
+                "hits": {
+                    key: {
+                        "title": h.title,
+                        "category": h.category,
+                        "matched": h.matched,
+                        "evidence": h.evidence,
+                        "official_reference": h.official_reference,
+                    }
+                    for key, h in sig.hits.items()
+                },
+            }
+            if sig.structural:
+                sq = sig.structural
+                result["signals"]["structural_quality"] = {
+                    "structural_score": round(sq.structural_score, 2),
+                    "skills_count": sq.skills_count,
+                    "skills_with_frontmatter": sq.skills_with_frontmatter,
+                    "skills_with_executable_content": sq.skills_with_executable_content,
+                    "skills_with_verification": sq.skills_with_verification,
+                    "skills_structured": sq.skills_structured,
+                    "hooks_present": sq.hooks_present,
+                    "hook_events": sq.hook_events,
+                    "subagents_count": sq.subagents_count,
+                    "workflows_present": sq.workflows_present,
+                    "plugins_present": sq.plugins_present,
+                }
+
         return result
 
     def report_single(self, score: RepoScore, output: TextIO = sys.stdout) -> None:
@@ -888,6 +967,50 @@ class MarkdownReporter:
 
                 print(file=output)
 
+        # 2026 context-engineering signals section
+        if score.signals:
+            sig = score.signals
+            print("## Context Engineering Signals (2026)", file=output)
+            print(file=output)
+            if sig.structural:
+                sq = sig.structural
+                print(f"- **Structural Quality:** {sq.structural_score:.1f}/10", file=output)
+                print(
+                    f"- **Primitives:** skills={sq.skills_count} "
+                    f"(frontmatter={sq.skills_with_frontmatter}, "
+                    f"executable={sq.skills_with_executable_content}, "
+                    f"verification={sq.skills_with_verification}), "
+                    f"hooks={'yes' if sq.hooks_present else 'no'}, "
+                    f"subagents={sq.subagents_count}, "
+                    f"workflows={'yes' if sq.workflows_present else 'no'}, "
+                    f"plugins={'yes' if sq.plugins_present else 'no'}",
+                    file=output,
+                )
+            if sig.bonus_points > 0:
+                print(f"- **Signal Bonus:** +{sig.bonus_points:.1f}", file=output)
+            print(file=output)
+
+            print("| Signal | Category | Detected | Evidence |", file=output)
+            print("|--------|----------|----------|----------|", file=output)
+            for key, h in sig.hits.items():
+                detected = "✓" if h.matched else "○"
+                ev = ", ".join(h.evidence[:3]) if h.evidence else ""
+                print(f"| {h.title} | {h.category} | {detected} | {ev} |", file=output)
+            print(file=output)
+
+            print("### Level Gates (L6-L8)", file=output)
+            print(file=output)
+            print("These signals are *required* (with file coverage) to reach the level.", file=output)
+            print(file=output)
+            print("| Level | Gate | Missing |", file=output)
+            print("|-------|------|---------|", file=output)
+            for lvl in (6, 7, 8):
+                if lvl in sig.gates:
+                    gate = ":white_check_mark: satisfied" if sig.gates[lvl] else ":o: blocked"
+                    missing = ", ".join(sig.gate_missing.get(lvl, [])) or "—"
+                    print(f"| L{lvl} | {gate} | {missing} |", file=output)
+            print(file=output)
+
         if score.recommendations:
             print("## Recommendations", file=output)
             print(file=output)
@@ -919,8 +1042,8 @@ class MarkdownReporter:
 
         print("## Repositories", file=output)
         print(file=output)
-        print("| Repository | Level | Score | Bonus | Quality | Status |", file=output)
-        print("|------------|-------|-------|-------|---------|--------|", file=output)
+        print("| Repository | Level | Score | Bonus | Quality | Gates (L6/7/8) | Status |", file=output)
+        print("|------------|-------|-------|-------|---------|----------------|--------|", file=output)
 
         sorted_scores = sorted(
             scores,
@@ -950,9 +1073,17 @@ class MarkdownReporter:
                     total_quality += avg_quality
                     repos_with_quality += 1
 
+            # Signal gate summary (L6/L7/L8)
+            gates_str = "-"
+            if score.signals and score.signals.gates:
+                g = score.signals.gates
+                gates_str = " ".join(
+                    f"{lvl}{'✓' if g.get(lvl) else '○'}" for lvl in (6, 7, 8)
+                )
+
             print(
                 f"| {score.repo_name} | Level {score.overall_level} | "
-                f"{score.overall_score:.1f} | {bonus_str} | {quality_str} | {status} |",
+                f"{score.overall_score:.1f} | {bonus_str} | {quality_str} | {gates_str} | {status} |",
                 file=output,
             )
 
@@ -979,8 +1110,10 @@ class CsvReporter:
     def report_multiple(self, scores: List[RepoScore], output: TextIO = sys.stdout) -> None:
         """Report multiple repository scores as CSV."""
 
-        # Header with levels 1-8, cross-reference columns, and validation columns
+        # Header: core + cross-reference + validation + 2026 signal columns,
+        # with the level_N_coverage columns kept last.
         header = "repo_name,repo_path,overall_level,overall_score,bonus_points,avg_quality,ref_count,resolved_count,validation_penalty,has_stale_files,has_templates,warning_count,ci_agents,handoffs_valid,outcomes_valid"
+        header += ",signal_bonus,structural_score,matched_signal_count,l6_gate,l7_gate,l8_gate"
         for i in range(1, 9):
             header += f",level_{i}_coverage"
         print(header, file=output)
@@ -1024,12 +1157,31 @@ class CsvReporter:
                     handoffs_valid = v.behavioral.level_7_ready
                     outcomes_valid = v.behavioral.level_8_ready
 
+            # 2026 signal data
+            signal_bonus = 0.0
+            structural_score = 0.0
+            matched_signal_count = 0
+            l6_gate = False
+            l7_gate = False
+            l8_gate = False
+            if score.signals:
+                sig = score.signals
+                signal_bonus = sig.bonus_points
+                matched_signal_count = len(sig.matched_keys)
+                if sig.structural:
+                    structural_score = sig.structural.structural_score
+                l6_gate = sig.gates.get(6, False)
+                l7_gate = sig.gates.get(7, False)
+                l8_gate = sig.gates.get(8, False)
+
             line = (
                 f'"{score.repo_name}","{score.repo_path}",{score.overall_level},'
                 f'{score.overall_score:.2f},{bonus:.2f},{avg_quality:.2f},'
                 f'{ref_count},{resolved_count},{validation_penalty:.2f},'
                 f'{has_stale},{has_templates},{warning_count},'
-                f'{ci_agents},{handoffs_valid},{outcomes_valid}'
+                f'{ci_agents},{handoffs_valid},{outcomes_valid},'
+                f'{signal_bonus:.2f},{structural_score:.2f},{matched_signal_count},'
+                f'{l6_gate},{l7_gate},{l8_gate}'
             )
             for cov in coverages:
                 line += f",{cov:.2f}"

--- a/measure_ai_proficiency/reporter.py
+++ b/measure_ai_proficiency/reporter.py
@@ -327,6 +327,8 @@ class TerminalReporter:
                     print(f"    {_color('⚠️', Colors.RED)} {warning}", file=output)
                 elif warning.startswith("INVALID SKILL:"):
                     print(f"    {_color('❌', Colors.RED)} {warning}", file=output)
+                elif warning.startswith("BLOAT:"):
+                    print(f"    {_color('🪶', Colors.YELLOW)} {warning}", file=output)
                 else:
                     print(f"    → {warning}", file=output)
 
@@ -669,6 +671,16 @@ class JsonReporter:
                     }
                     for path, s in v.skill_validations.items()
                 },
+                "conciseness": {
+                    path: {
+                        "word_count": c.word_count,
+                        "is_always_on": c.is_always_on,
+                        "routing_ref_count": c.routing_ref_count,
+                        "threshold": c.threshold,
+                        "is_bloated": c.is_bloated,
+                    }
+                    for path, c in v.conciseness.items()
+                },
             }
 
             # Add behavioral analysis if present
@@ -913,6 +925,8 @@ class MarkdownReporter:
                         print(f"- :warning: {warning}", file=output)
                     elif warning.startswith("INVALID SKILL:"):
                         print(f"- :x: {warning}", file=output)
+                    elif warning.startswith("BLOAT:"):
+                        print(f"- :feather: {warning}", file=output)
                     else:
                         print(f"- {warning}", file=output)
 

--- a/measure_ai_proficiency/scanner.py
+++ b/measure_ai_proficiency/scanner.py
@@ -391,6 +391,25 @@ class HarnessSignals:
 
 
 @dataclass
+class ConcisenessAnalysis:
+    """Conciseness / context-hygiene metrics for an always-on instruction file.
+
+    Always-loaded files (CLAUDE.md / AGENTS.md / copilot-instructions) are a
+    permanent context tax: large monolithic files degrade results and crowd out
+    working context. Mature setups keep a thin routing layer and push detail into
+    scoped, on-demand files (skills, "See X.md" pointers). Skill bodies are loaded
+    on demand (progressive disclosure), so they are NOT flagged here.
+    """
+
+    file_path: str
+    word_count: int
+    is_always_on: bool         # True for always-loaded floor files (not on-demand skills)
+    routing_ref_count: int     # links/pointers that offload detail to other files
+    threshold: int             # configured bloat threshold (words)
+    is_bloated: bool           # always-on AND over the threshold
+
+
+@dataclass
 class ValidationResult:
     """Combined validation results for a repository (Improvements 2-4)."""
 
@@ -398,6 +417,7 @@ class ValidationResult:
     alignment_scores: Dict[str, AlignmentScore] = field(default_factory=dict)
     template_analyses: Dict[str, TemplateAnalysis] = field(default_factory=dict)
     skill_validations: Dict[str, SkillValidation] = field(default_factory=dict)
+    conciseness: Dict[str, ConcisenessAnalysis] = field(default_factory=dict)
     stale_references: List[StaleReference] = field(default_factory=list)
     validation_penalty: float = 0.0  # Score reduction for validation issues
     behavioral: Optional[BehavioralAnalysis] = None  # Level 6-8 behavioral analysis
@@ -417,9 +437,22 @@ class ValidationResult:
         )
 
     @property
+    def has_bloat(self) -> bool:
+        return any(c.is_bloated for c in self.conciseness.values())
+
+    @property
     def warnings(self) -> List[str]:
         """Generate warning messages for validation issues."""
         warnings = []
+
+        # Conciseness / context-hygiene warnings (oversized always-on files)
+        for path, c in self.conciseness.items():
+            if c.is_bloated:
+                warnings.append(
+                    f"BLOAT: {path} is {c.word_count} words (> {c.threshold}) — large "
+                    f"always-on files are a permanent context tax; move detail into "
+                    f"scoped files/skills and keep a thin routing layer"
+                )
 
         # Freshness warnings
         for path, freshness in self.freshness_scores.items():
@@ -578,6 +611,12 @@ class RepoScanner:
     @property
     def _word_threshold_full(self) -> int:
         return self.config.word_threshold_full if self.config else 200
+
+    @property
+    def _word_threshold_bloat(self) -> int:
+        # Always-on instruction files beyond this word count are flagged as a
+        # context-engineering bloat / permanent context tax (configurable).
+        return self.config.word_threshold_bloat if self.config else 1500
 
     @property
     def _git_timeout(self) -> int:
@@ -1076,6 +1115,9 @@ class RepoScanner:
             template = self._detect_template_content(content, rel_path)
             result.template_analyses[rel_path] = template
 
+            # Conciseness / context-hygiene (oversized always-on files)
+            result.conciseness[rel_path] = self._analyze_conciseness(content, rel_path)
+
         # Improvement 4: Skill validation
         skill_files = self._find_skill_files()
         for skill_path in skill_files:
@@ -1092,6 +1134,30 @@ class RepoScanner:
         result.behavioral = self._analyze_behavioral_patterns()
 
         return result
+
+    def _analyze_conciseness(self, content: str, rel_path: str) -> ConcisenessAnalysis:
+        """Flag oversized always-on instruction files (context-hygiene / anti-bloat).
+
+        Only the always-loaded "floor" files (CLAUDE.md / AGENTS.md /
+        copilot-instructions, etc.) are subject to the bloat threshold — on-demand
+        skill bodies are exempt by design (progressive disclosure).
+        """
+        word_count = len(content.split())
+        is_always_on = rel_path in INSTRUCTION_FILES
+        # Count references that offload detail to other files (thin routing layer)
+        try:
+            routing_refs = self._extract_path_references(content)
+        except Exception:
+            routing_refs = []
+        threshold = self._word_threshold_bloat
+        return ConcisenessAnalysis(
+            file_path=rel_path,
+            word_count=word_count,
+            is_always_on=is_always_on,
+            routing_ref_count=len(routing_refs),
+            threshold=threshold,
+            is_bloated=is_always_on and word_count > threshold,
+        )
 
     def _get_latest_code_commit_time(self) -> Optional[datetime]:
         """Get the timestamp of the most recent code commit (excluding context files)."""
@@ -1443,6 +1509,7 @@ class RepoScanner:
         - 2 points per stale file (max 6)
         - 1 point per invalid reference (max 4)
         - 2 points if majority of files are templates
+        - up to 3 points for oversized always-on files (context-hygiene / bloat)
 
         Total max penalty: 10 points
         """
@@ -1463,6 +1530,15 @@ class RepoScanner:
             template_count = sum(1 for t in result.template_analyses.values() if t.is_template)
             if template_count > len(result.template_analyses) / 2:
                 penalty += 2.0
+
+        # Penalty for bloated always-on files (context-hygiene). Scales with how far
+        # over the threshold the worst offender is; capped at 3 points.
+        bloat_penalty = 0.0
+        for c in result.conciseness.values():
+            if c.is_bloated and c.threshold > 0:
+                overage = (c.word_count / c.threshold) - 1.0  # 0 at threshold, 1.0 at 2x
+                bloat_penalty = max(bloat_penalty, min(overage * 2.0, 3.0))
+        penalty += bloat_penalty
 
         return min(penalty, 10.0)
 

--- a/measure_ai_proficiency/scanner.py
+++ b/measure_ai_proficiency/scanner.py
@@ -2893,6 +2893,23 @@ class RepoScanner:
         # Append 2026 signal-gap recommendations (verification, hooks, harness,
         # dynamic workflows, maintenance hygiene) grounded in official docs.
         recs.extend(self._signal_gap_recommendations(score))
+
+        # Conciseness / anti-bloat recommendation for oversized always-on files.
+        if score.validation and score.validation.has_bloat and not self._should_skip(score.config, "bloat"):
+            bloated = sorted(
+                (c for c in score.validation.conciseness.values() if c.is_bloated),
+                key=lambda c: c.word_count,
+                reverse=True,
+            )
+            names = ", ".join(c.file_path for c in bloated[:3])
+            recs.append(
+                f"🪶 Trim your always-on files ({names}): they are a permanent context tax, and "
+                f"bloated files make the model ignore your actual instructions. Audit rule: every "
+                f"always-loaded line must change behavior, or cut it — ask \"what would go wrong if "
+                f"this line wasn't here?\". Move detail into on-demand skills (progressive disclosure) "
+                f"and keep a thin routing layer. See docs/AGENTS_FILE_GUIDANCE.md and "
+                f"https://docs.claude.com/en/docs/claude-code/memory"
+            )
         return recs
 
     def _signal_gap_recommendations(self, score: RepoScore) -> List[str]:

--- a/measure_ai_proficiency/scanner.py
+++ b/measure_ai_proficiency/scanner.py
@@ -15,6 +15,13 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set
 
 from .config import LEVELS, CORE_AI_FILES, LevelConfig, filter_patterns_for_tools
+from .signals import (
+    SIGNAL_GROUPS,
+    SIGNAL_GROUPS_BY_KEY,
+    LEVEL_GATE_REQUIREMENTS,
+    GATE_REQUIREMENT_LABELS,
+    GATE_REQUIREMENT_REFERENCES,
+)
 from .repo_config import (
     RepoConfig,
     load_repo_config,
@@ -291,6 +298,99 @@ class BehavioralAnalysis:
 
 
 @dataclass
+class StructuralQuality:
+    """Structural-quality metrics for the 6 primitives (2026 signals).
+
+    Goes beyond presence: detects YAML frontmatter, executable content, and
+    verification inside skills, plus deterministic hooks, subagents, workflows,
+    and plugin manifests.
+    """
+
+    skills_count: int = 0
+    skills_with_frontmatter: int = 0
+    skills_with_executable_content: int = 0
+    skills_with_verification: int = 0
+    hooks_present: bool = False
+    hook_events: List[str] = field(default_factory=list)
+    subagents_count: int = 0
+    workflows_present: bool = False
+    plugins_present: bool = False
+
+    @property
+    def skills_structured(self) -> bool:
+        """True if at least one skill has real structure (frontmatter or scripts)."""
+        return self.skills_count > 0 and (
+            self.skills_with_frontmatter > 0 or self.skills_with_executable_content > 0
+        )
+
+    @property
+    def structural_score(self) -> float:
+        """0-10 structural-quality score across the primitives."""
+        score = 0.0
+        if self.skills_count > 0:
+            score += 1.0
+        if self.skills_with_frontmatter > 0:
+            score += 1.5
+        if self.skills_with_executable_content > 0:
+            score += 1.5
+        if self.skills_with_verification > 0:
+            score += 1.0
+        if self.hooks_present:
+            score += 1.5
+        if self.subagents_count >= 2:
+            score += 1.5
+        elif self.subagents_count == 1:
+            score += 0.5
+        if self.workflows_present:
+            score += 1.0
+        if self.plugins_present:
+            score += 1.0
+        return min(score, 10.0)
+
+
+@dataclass
+class SignalHit:
+    """A single 2026 content-signal detection result."""
+
+    key: str
+    title: str
+    category: str
+    matched: bool
+    evidence: List[str] = field(default_factory=list)
+    official_reference: str = ""
+
+
+@dataclass
+class HarnessSignals:
+    """2026 context-engineering signals: content hits + structural quality + gates.
+
+    These rewire the L6-L8 ladder: reaching those levels requires the matching
+    signals (resolved in scanner._compute_signal_gates), not file coverage alone.
+    """
+
+    hits: Dict[str, SignalHit] = field(default_factory=dict)
+    structural: Optional[StructuralQuality] = None
+    bonus_points: float = 0.0
+    gates: Dict[int, bool] = field(default_factory=dict)               # level -> satisfied
+    gate_missing: Dict[int, List[str]] = field(default_factory=dict)   # level -> missing reqs
+
+    @property
+    def matched_keys(self) -> List[str]:
+        return [k for k, h in self.hits.items() if h.matched]
+
+    @property
+    def warnings(self) -> List[str]:
+        """Human-readable gate gaps (e.g. 'SIGNAL GAP (L7): missing telemetry...')."""
+        out: List[str] = []
+        for level in sorted(self.gate_missing):
+            missing = self.gate_missing[level]
+            if missing:
+                labels = "; ".join(GATE_REQUIREMENT_LABELS.get(m, m) for m in missing)
+                out.append(f"SIGNAL GAP (L{level}): missing {labels}")
+        return out
+
+
+@dataclass
 class ValidationResult:
     """Combined validation results for a repository (Improvements 2-4)."""
 
@@ -434,6 +534,7 @@ class RepoScore:
     effective_thresholds: Dict[int, int] = field(default_factory=dict)  # Level -> % threshold
     default_level: Optional[int] = None  # Level with default thresholds (when custom are used)
     validation: Optional[ValidationResult] = None  # Content validation results (Improvements 2-4)
+    signals: Optional["HarnessSignals"] = None  # 2026 context-engineering signals (gates L6-8)
 
     @property
     def has_any_ai_files(self) -> bool:
@@ -458,6 +559,7 @@ class RepoScanner:
         self.repo_path = Path(repo_path).resolve()
         self.verbose = verbose
         self._dir_cache: Dict[str, bool] = {}
+        self._instruction_files_cache: Optional[List[Path]] = None
         self.config: Optional[RepoConfig] = None
 
     # Config getters with defaults (used before config is loaded)
@@ -486,6 +588,10 @@ class RepoScanner:
 
         scan_time = datetime.now()
 
+        # Reset per-scan caches
+        self._instruction_files_cache = None
+        self._dir_cache = {}
+
         # Load repository config (auto-detection + .ai-proficiency.yaml)
         self.config = load_repo_config(self.repo_path)
 
@@ -509,8 +615,15 @@ class RepoScanner:
         # Perform content validation (Improvements 2-4)
         score.validation = self._validate_content()
 
-        # Calculate overall level and score (using custom thresholds if configured)
-        score.overall_level, score.effective_thresholds, score.default_level = self._calculate_overall_level(score.level_scores)
+        # Analyze 2026 context-engineering signals (gates L6-8 + bonus)
+        behavioral = score.validation.behavioral if score.validation else None
+        score.signals = self._analyze_signals(behavioral)
+
+        # Calculate overall level and score (using custom thresholds if configured).
+        # Signal gates can cap the achieved level for L6-8 (2026 rewire).
+        score.overall_level, score.effective_thresholds, score.default_level = (
+            self._calculate_overall_level(score.level_scores, score.signals)
+        )
 
         # Calculate base score with minimum per level and validation penalty
         validation_penalty = score.validation.validation_penalty if score.validation else 0.0
@@ -520,8 +633,11 @@ class RepoScanner:
             validation_penalty
         )
 
-        # Add cross-reference bonus to overall score (capped at 100)
-        score.overall_score = min(100, base_score + score.cross_references.bonus_points)
+        # Add cross-reference + signal bonuses to overall score (capped at 100)
+        signal_bonus = score.signals.bonus_points if score.signals else 0.0
+        score.overall_score = min(
+            100, base_score + score.cross_references.bonus_points + signal_bonus
+        )
 
         # Generate recommendations (tool-specific)
         score.recommendations = self._generate_recommendations(score)
@@ -707,7 +823,15 @@ class RepoScanner:
         )
 
     def _find_instruction_files(self) -> List[Path]:
-        """Find AI instruction files to scan for cross-references."""
+        """Find AI instruction files to scan for cross-references.
+
+        Memoized per scan run: several passes (validation, signals, success
+        tracking) need this list, and re-globbing the filesystem each time is
+        slow on large or network-backed repositories. The cache is reset at the
+        start of each scan().
+        """
+        if self._instruction_files_cache is not None:
+            return self._instruction_files_cache
 
         files: List[Path] = []
 
@@ -739,6 +863,7 @@ class RepoScanner:
             except (OSError, PermissionError):
                 pass
 
+        self._instruction_files_cache = files
         return files
 
     def _read_file_safe(self, path: Path) -> Optional[str]:
@@ -1554,6 +1679,303 @@ class RepoScanner:
                 pass
         return False
 
+    # =========================================================================
+    # 2026 Context-Engineering Signal Analysis
+    # =========================================================================
+
+    def _analyze_signals(self, behavioral: Optional[BehavioralAnalysis] = None) -> HarnessSignals:
+        """Detect 2026 context-engineering signals; compute L6-8 gates + bonus."""
+        text = self._concat_instruction_text()
+        structural = self._detect_structural_quality()
+
+        hits: Dict[str, SignalHit] = {}
+        for group in SIGNAL_GROUPS:
+            evidence: List[str] = []
+            for pattern in group.keyword_patterns:
+                try:
+                    match = re.search(pattern, text, re.IGNORECASE)
+                except re.error:
+                    continue
+                if match:
+                    token = match.group(0).strip()
+                    if token and token not in evidence:
+                        evidence.append(token)
+
+            # Reinforce select signals with filesystem structural evidence
+            if group.key == "hooks" and structural.hooks_present:
+                for event in structural.hook_events:
+                    if event not in evidence:
+                        evidence.append(event)
+                if not evidence:
+                    evidence.append(".claude/hooks")
+            elif group.key == "dynamic_workflows" and structural.workflows_present:
+                if ".claude/workflows/" not in evidence:
+                    evidence.append(".claude/workflows/")
+            elif group.key == "plugins" and structural.plugins_present:
+                if ".claude-plugin" not in evidence:
+                    evidence.append(".claude-plugin")
+            elif group.key == "eval_loops" and self._has_eval_infra():
+                if ".evals/" not in evidence:
+                    evidence.append(".evals/")
+            elif group.key == "verification" and structural.skills_with_verification > 0:
+                marker = f"{structural.skills_with_verification} verification skill(s)"
+                if marker not in evidence:
+                    evidence.append(marker)
+
+            hits[group.key] = SignalHit(
+                key=group.key,
+                title=group.title,
+                category=group.category,
+                matched=len(evidence) > 0,
+                evidence=evidence[:6],
+                official_reference=group.official_reference,
+            )
+
+        # measured_outcomes is a structural/behavioral signal (metrics, logs,
+        # success tracking) rather than a keyword group, but it gates L8 — surface
+        # it as a hit so reports and the harness MCP tool show it. It is not in
+        # SIGNAL_GROUPS, so it does not contribute to the keyword signal bonus.
+        outcome_evidence: List[str] = []
+        if behavioral and behavioral.outcomes:
+            outcome_evidence = [k for k, v in behavioral.outcomes.indicators.items() if v]
+        hits["measured_outcomes"] = SignalHit(
+            key="measured_outcomes",
+            title="Measured Outcomes",
+            category="harness",
+            matched=bool(behavioral and behavioral.level_8_ready),
+            evidence=outcome_evidence[:6],
+            official_reference=GATE_REQUIREMENT_REFERENCES.get("measured_outcomes", ""),
+        )
+
+        gates, gate_missing = self._compute_signal_gates(hits, structural, behavioral)
+        bonus = self._compute_signal_bonus(hits, structural)
+
+        return HarnessSignals(
+            hits=hits,
+            structural=structural,
+            bonus_points=bonus,
+            gates=gates,
+            gate_missing=gate_missing,
+        )
+
+    def _concat_instruction_text(self) -> str:
+        """Concatenate instruction + skill + hook/workflow text for signal scanning."""
+        parts: List[str] = []
+        for path in self._find_instruction_files():
+            content = self._read_file_safe(path)
+            if content:
+                parts.append(content)
+
+        # Include hook/workflow scripts for richer keyword detection.
+        # Cap the number of files read per directory to bound work/memory on
+        # pathological repos (each file is already size-capped by _read_file_safe).
+        max_files_per_dir = 50
+        for sub in (".claude/hooks", ".claude/workflows"):
+            directory = self.repo_path / sub
+            if directory.is_dir():
+                try:
+                    read = 0
+                    for item in sorted(directory.rglob("*")):
+                        if read >= max_files_per_dir:
+                            break
+                        if item.is_file():
+                            content = self._read_file_safe(item)
+                            if content:
+                                parts.append(content)
+                                read += 1
+                except (OSError, PermissionError):
+                    pass
+
+        # Include settings (hook configuration lives here)
+        for rel in (".claude/settings.json", ".claude/settings.local.json"):
+            path = self.repo_path / rel
+            if path.is_file():
+                content = self._read_file_safe(path)
+                if content:
+                    parts.append(content)
+
+        return "\n".join(parts)
+
+    def _detect_structural_quality(self) -> StructuralQuality:
+        """Detect structural quality across the 6 primitives (2026)."""
+        sq = StructuralQuality()
+
+        # --- Skills: frontmatter, executable content, verification ---
+        skill_files = self._find_skill_files()
+        sq.skills_count = len(skill_files)
+        for skill in skill_files:
+            content = self._read_file_safe(skill)
+            if not content:
+                continue
+            if content.lstrip().startswith("---"):
+                sq.skills_with_frontmatter += 1
+            # Executable / data content = non-.md files alongside the skill
+            try:
+                has_exec = any(
+                    item.is_file() and item.suffix.lower() not in ("", ".md")
+                    for item in skill.parent.rglob("*")
+                )
+            except (OSError, PermissionError):
+                has_exec = False
+            if has_exec:
+                sq.skills_with_executable_content += 1
+            lowered = content.lower()
+            if any(term in lowered for term in ("verif", "assert", "validate", "eval", "test")):
+                sq.skills_with_verification += 1
+
+        # --- Hooks: settings.json + .claude/hooks + event keywords ---
+        hooks_present = False
+        hooks_dir = self.repo_path / ".claude" / "hooks"
+        if hooks_dir.is_dir():
+            try:
+                hooks_present = any(hooks_dir.iterdir())
+            except (OSError, PermissionError):
+                hooks_present = False
+
+        settings_text = ""
+        for rel in (".claude/settings.json", ".claude/settings.local.json"):
+            path = self.repo_path / rel
+            if path.is_file():
+                content = self._read_file_safe(path)
+                if content:
+                    settings_text += content
+        if '"hooks"' in settings_text:
+            hooks_present = True
+
+        hook_events: Set[str] = set()
+        for event in (
+            "PreToolUse", "PostToolUse", "SessionStart", "Stop",
+            "SubagentStop", "UserPromptSubmit", "PreCompact", "Notification",
+        ):
+            if event in settings_text:
+                hook_events.add(event)
+                hooks_present = True
+        sq.hooks_present = hooks_present
+        sq.hook_events = sorted(hook_events)
+
+        # --- Subagents: agent definition files ---
+        sq.subagents_count = self._count_subagent_files()
+
+        # --- Workflows: .claude/workflows with files ---
+        wf_dir = self.repo_path / ".claude" / "workflows"
+        if wf_dir.is_dir():
+            try:
+                sq.workflows_present = any(item.is_file() for item in wf_dir.iterdir())
+            except (OSError, PermissionError):
+                sq.workflows_present = False
+
+        # --- Plugins: .claude-plugin manifest anywhere ---
+        sq.plugins_present = self._has_plugin_manifest()
+
+        return sq
+
+    def _count_subagent_files(self) -> int:
+        """Count unique subagent definition files across known locations."""
+        agent_dirs = [
+            self.repo_path / ".claude" / "agents",
+            self.repo_path / ".github" / "agents",
+            self.repo_path / "agents",
+        ]
+        seen: Set[str] = set()
+        for agent_dir in agent_dirs:
+            if agent_dir.is_dir():
+                try:
+                    for f in agent_dir.glob("*.md"):
+                        if f.is_file():
+                            seen.add(str(f.resolve()))
+                except (OSError, PermissionError):
+                    pass
+        return len(seen)
+
+    def _has_plugin_manifest(self) -> bool:
+        """True if a Claude plugin/marketplace manifest exists anywhere relevant."""
+        direct = [
+            self.repo_path / ".claude-plugin" / "plugin.json",
+            self.repo_path / ".claude-plugin" / "marketplace.json",
+        ]
+        if any(p.is_file() for p in direct):
+            return True
+        for base in (self.repo_path / ".claude" / "plugins", self.repo_path / "plugins"):
+            if base.is_dir():
+                try:
+                    for name in ("plugin.json", "marketplace.json"):
+                        for manifest in base.rglob(name):
+                            if manifest.is_file():
+                                return True
+                except (OSError, PermissionError):
+                    pass
+        return False
+
+    def _has_eval_infra(self) -> bool:
+        """True if an eval/regression directory with cases exists."""
+        for rel in (".evals", "evals"):
+            directory = self.repo_path / rel
+            if directory.is_dir():
+                try:
+                    if any(directory.rglob("*.md")):
+                        return True
+                except (OSError, PermissionError):
+                    pass
+        return False
+
+    def _compute_signal_gates(
+        self,
+        hits: Dict[str, SignalHit],
+        structural: StructuralQuality,
+        behavioral: Optional[BehavioralAnalysis],
+    ) -> tuple:
+        """Resolve L6-8 gate requirements.
+
+        Returns (gates, gate_missing). gates[level] is True only when ALL of that
+        level's requirements are satisfied. Because _calc_level_with_thresholds
+        walks the ladder monotonically (a failed gate at level N breaks the loop),
+        the requirements are effectively cumulative: a repo cannot reach L7/L8
+        while its L6 gate is unmet, even if higher signals are present.
+        """
+        def matched(key: str) -> bool:
+            hit = hits.get(key)
+            return bool(hit and hit.matched)
+
+        # Resolved once; the eval-infra directory check is reused below.
+        has_eval_infra = self._has_eval_infra()
+
+        resolved: Dict[str, bool] = {
+            # Verification (L6) is verification *discipline* in instructions/skills —
+            # distinct from L7 eval-loop infrastructure (.evals), so it does NOT
+            # fall back to has_eval_infra.
+            "structured_skills": structural.skills_structured,
+            "hooks": structural.hooks_present or matched("hooks"),
+            "subagents": structural.subagents_count >= 2,
+            "verification": matched("verification"),
+            "eval_loops": matched("eval_loops") or has_eval_infra,
+            "telemetry": matched("telemetry"),
+            "maintenance_hygiene": matched("maintenance_hygiene"),
+            "orchestration": structural.workflows_present or matched("dynamic_workflows"),
+            "plugins": structural.plugins_present or matched("plugins"),
+            "measured_outcomes": bool(behavioral and behavioral.level_8_ready),
+        }
+
+        gates: Dict[int, bool] = {}
+        gate_missing: Dict[int, List[str]] = {}
+        for level, requirements in LEVEL_GATE_REQUIREMENTS.items():
+            missing = [req for req in requirements if not resolved.get(req, False)]
+            gates[level] = len(missing) == 0
+            gate_missing[level] = missing
+        return gates, gate_missing
+
+    def _compute_signal_bonus(
+        self, hits: Dict[str, SignalHit], structural: StructuralQuality
+    ) -> float:
+        """Bounded bonus (0-10) from matched signals + structural quality."""
+        signal_points = 0.0
+        for key, hit in hits.items():
+            if hit.matched:
+                group = SIGNAL_GROUPS_BY_KEY.get(key)
+                if group:
+                    signal_points += group.weight
+        structural_points = structural.structural_score / 4.0  # up to ~2.5 pts
+        return min(10.0, signal_points + structural_points)
+
     # Default thresholds for level advancement (percentage coverage required)
     DEFAULT_THRESHOLDS: Dict[int, int] = {
         3: 15,   # Comprehensive context
@@ -1564,13 +1986,21 @@ class RepoScanner:
         8: 5,    # Custom orchestration (frontier)
     }
 
-    def _calculate_overall_level(self, level_scores: Dict[int, LevelScore]) -> tuple:
+    def _calculate_overall_level(
+        self,
+        level_scores: Dict[int, LevelScore],
+        signals: Optional[HarnessSignals] = None,
+    ) -> tuple:
         """
         Calculate the overall maturity level (1-8) and return effective thresholds.
 
+        Levels 6-8 are additionally gated on 2026 context-engineering signals
+        (when ``signals`` is provided): file coverage alone is no longer enough —
+        the matching primitives/harness/orchestration signals must also be present.
+
         Returns:
             tuple: (overall_level, effective_thresholds, default_level)
-            - overall_level: Level achieved with effective thresholds
+            - overall_level: Level achieved with effective thresholds + signal gates
             - effective_thresholds: Dict of thresholds used (custom if configured)
             - default_level: Level that would be achieved with default thresholds (None if no custom)
         """
@@ -1593,23 +2023,40 @@ class RepoScanner:
         if not has_core_file:
             return 1, thresholds, None  # No core AI file = Level 1
 
+        # Signal gates for L6-8 (None => no gating, backward compatible)
+        gates = signals.gates if signals else None
+
         # Calculate level with effective thresholds
-        current_level = self._calc_level_with_thresholds(level_scores, thresholds)
+        current_level = self._calc_level_with_thresholds(level_scores, thresholds, gates)
 
         # Calculate default level if custom thresholds are in use
         default_level = None
         if has_custom:
-            default_level = self._calc_level_with_thresholds(level_scores, self.DEFAULT_THRESHOLDS)
+            default_level = self._calc_level_with_thresholds(
+                level_scores, self.DEFAULT_THRESHOLDS, gates
+            )
 
         return current_level, thresholds, default_level
 
-    def _calc_level_with_thresholds(self, level_scores: Dict[int, LevelScore], thresholds: Dict[int, int]) -> int:
-        """Calculate level using given thresholds."""
+    def _calc_level_with_thresholds(
+        self,
+        level_scores: Dict[int, LevelScore],
+        thresholds: Dict[int, int],
+        gates: Optional[Dict[int, bool]] = None,
+    ) -> int:
+        """Calculate level using given thresholds and optional L6-8 signal gates."""
         current_level = 2
         for level_num in range(3, 9):
             level_score = level_scores.get(level_num)
             threshold = thresholds.get(level_num, 5)
-            if level_score and level_score.coverage_percent >= threshold:
+            coverage_ok = bool(level_score and level_score.coverage_percent >= threshold)
+
+            # Signal gate (only constrains levels present in the gates dict, i.e. 6-8)
+            gate_ok = True
+            if gates is not None and level_num in gates:
+                gate_ok = gates[level_num]
+
+            if coverage_ok and gate_ok:
                 current_level = level_num
             else:
                 break
@@ -2365,9 +2812,49 @@ class RepoScanner:
         }
 
         handler = handlers.get(score.overall_level)
-        if handler:
-            return handler()
-        return []
+        recs = handler() if handler else []
+
+        # Append 2026 signal-gap recommendations (verification, hooks, harness,
+        # dynamic workflows, maintenance hygiene) grounded in official docs.
+        recs.extend(self._signal_gap_recommendations(score))
+        return recs
+
+    def _signal_gap_recommendations(self, score: RepoScore) -> List[str]:
+        """Recommend the missing 2026 signals needed to reach the next level."""
+        recs: List[str] = []
+        signals = score.signals
+        if not signals or self._should_skip(score.config, "signals"):
+            return recs
+
+        emoji = {
+            "structured_skills": "📚",
+            "hooks": "🪝",
+            "subagents": "🤝",
+            "verification": "✅",
+            "eval_loops": "🧪",
+            "telemetry": "📈",
+            "maintenance_hygiene": "🧹",
+            "orchestration": "🪢",
+            "plugins": "🧩",
+            "measured_outcomes": "📊",
+        }
+
+        # Surface gate gaps for the current level (if any) and the next level.
+        next_level = min(score.overall_level + 1, 8)
+        targets = sorted({lvl for lvl in (score.overall_level, next_level) if lvl in (6, 7, 8)})
+
+        seen: Set[str] = set()
+        for level in targets:
+            for req in signals.gate_missing.get(level, []):
+                if req in seen:
+                    continue
+                seen.add(req)
+                label = GATE_REQUIREMENT_LABELS.get(req, req)
+                ref = GATE_REQUIREMENT_REFERENCES.get(req, "")
+                icon = emoji.get(req, "➤")
+                suffix = f" See {ref}" if ref else ""
+                recs.append(f"{icon} For Level {level}: add {label}.{suffix}")
+        return recs
 
 
 def scan_multiple_repos(repo_paths: List[str], verbose: bool = False) -> List[RepoScore]:

--- a/measure_ai_proficiency/signals.py
+++ b/measure_ai_proficiency/signals.py
@@ -1,0 +1,333 @@
+"""
+2026 context-engineering signal detection.
+
+This module defines *content/structural* signals that go beyond file presence:
+verification discipline, eval loops, deterministic hooks, telemetry/observability,
+anti-drift maintenance hygiene, dynamic-workflow orchestration, harness engineering,
+primitive decision discipline, plugin distribution, and curricula on-ramps.
+
+These signals are how the scanner rewires Levels 6-8: reaching those levels requires
+the matching signals (and file coverage), not file presence alone.
+
+GROUNDING — every signal is grounded ONLY in official documentation and primary
+sources. No social-media handles or attributions are encoded here.
+
+  - Claude Code docs ............. https://docs.claude.com/en/docs/claude-code
+  - Dynamic Workflows ........... https://code.claude.com/docs/en/workflows
+  - Hooks ....................... https://docs.claude.com/en/docs/claude-code/hooks
+  - Skills ...................... https://docs.claude.com/en/docs/claude-code/skills
+  - Sub-agents .................. https://docs.claude.com/en/docs/claude-code/sub-agents
+  - Plugins ..................... https://docs.claude.com/en/docs/claude-code/plugins
+  - MCP ......................... https://modelcontextprotocol.io
+  - Agent Skills standard ....... https://agentskills.io
+  - Harness research ............ arXiv:2603.28052 (Meta-Harness),
+                                  arXiv:2605.22166 (Life-Harness)
+  - Anthropic Academy (free courses) and the Google "5-Day AI Agents" course
+    (Day 3 explicitly covers Context Engineering) ground the curricula signal.
+
+IMPORTANT (per the proficiency-signals research): static repository scans cannot
+measure *runtime* efficacy. These signals detect documented *proxies* in committed
+artifacts — they do not assert that dynamic workflows or eval loops actually run.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+# Signal categories used to group hits in reports.
+CATEGORY_HARNESS = "harness"
+CATEGORY_ORCHESTRATION = "orchestration"
+CATEGORY_MAINTENANCE = "maintenance"
+CATEGORY_PRIMITIVE = "primitive"
+CATEGORY_CURRICULA = "curricula"
+
+
+@dataclass(frozen=True)
+class SignalGroup:
+    """A content signal detectable via keyword/regex over instruction files.
+
+    Patterns are matched case-insensitively as regular expressions against the
+    concatenated text of a repository's AI instruction files.
+    """
+
+    key: str                      # stable slug, e.g. "verification"
+    title: str                    # display title
+    category: str                 # one of the CATEGORY_* constants
+    description: str              # what this signal indicates
+    keyword_patterns: List[str]   # regex strings (matched case-insensitively)
+    weight: float                 # contribution to the bounded signal bonus
+    official_reference: str       # OFFICIAL doc/source only — never a handle
+
+
+# =============================================================================
+# Signal registry
+# =============================================================================
+# Ordered roughly by the level gate they feed (L6 -> L7 -> L8), then proxies.
+
+SIGNAL_GROUPS: List[SignalGroup] = [
+    # ---- L6 gate contributors -------------------------------------------------
+    SignalGroup(
+        key="verification",
+        title="Verification Discipline",
+        category=CATEGORY_HARNESS,
+        description=(
+            "Explicit verification: adversarial/clean-context review, binary "
+            "completion criteria, TDD, asserts, self-review before done."
+        ),
+        keyword_patterns=[
+            r"\bverif(?:y|ication|ied)\b",
+            r"\badversarial\b",
+            r"\brefut(?:e|ation)\b",
+            r"\bclean[- ]context\b",
+            r"\bbinary completion\b",
+            r"\bcompletion criteria\b",
+            r"\bfailing test first\b",
+            r"\bred[- ]green(?:[- ]refactor)?\b",
+            r"\btest[- ]driven\b|\bTDD\b",
+            r"\bassert(?:ion)?s?\b",
+            r"\bdouble[- ]check\b",
+            r"\bself[- ]review\b",
+            r"\bverified read\b",
+        ],
+        weight=1.4,
+        official_reference="https://docs.claude.com/en/docs/claude-code/hooks; arXiv:2603.28052",
+    ),
+    SignalGroup(
+        key="hooks",
+        title="Deterministic Hooks",
+        category=CATEGORY_PRIMITIVE,
+        description=(
+            "Deterministic (non-LLM) lifecycle guardrails: PreToolUse/PostToolUse/"
+            "SessionStart/Stop/SubagentStop matchers enforcing policy or formatting."
+        ),
+        keyword_patterns=[
+            r"\bPreToolUse\b",
+            r"\bPostToolUse\b",
+            r"\bSessionStart\b",
+            r"\bSubagentStop\b",
+            r"\bUserPromptSubmit\b",
+            r"\bdeterministic guardrail\b",
+            r"\bON-EDIT\b|\bon[- ]edit hook\b",
+            r"\bhooks?\b(?=.{0,40}(?:tool|edit|commit|lint|format|block))",
+        ],
+        weight=1.4,
+        official_reference="https://docs.claude.com/en/docs/claude-code/hooks",
+    ),
+    SignalGroup(
+        key="primitive_discipline",
+        title="Primitive Decision Discipline",
+        category=CATEGORY_PRIMITIVE,
+        description=(
+            "Cheapest-primitive-first decision logic and progressive disclosure: "
+            "choosing skill vs subagent vs MCP vs hook deliberately."
+        ),
+        keyword_patterns=[
+            r"\bprogressive disclosure\b",
+            r"\bcheapest primitive\b",
+            r"\bskill vs (?:subagent|mcp|hook)\b",
+            r"\bwhen to use a (?:skill|subagent|hook|plugin)\b",
+            r"\bleast[- ]privilege\b",
+            r"\bearn(?:ed)? complexity\b",
+            r"\bdecision tree\b",
+            r"\bMCP for reach\b|\bskills for knowledge\b",
+        ],
+        weight=1.0,
+        official_reference="https://docs.claude.com/en/docs/claude-code/skills; https://agentskills.io",
+    ),
+    # ---- L7 gate contributors -------------------------------------------------
+    SignalGroup(
+        key="eval_loops",
+        title="Eval / Regression Loops",
+        category=CATEGORY_HARNESS,
+        description=(
+            "Systematic evaluation infrastructure: eval cases, regression suites, "
+            "held-out validation, golden tests, benchmark gates."
+        ),
+        keyword_patterns=[
+            r"\beval(?:uation)? (?:case|loop|suite|harness|gate)s?\b",
+            r"\bregression (?:test|suite|check|guard)s?\b",
+            r"\bheld[- ]out\b",
+            r"\bgolden (?:test|file|output)s?\b",
+            r"\bbenchmark(?:s|ed|ing)?\b",
+            r"\beval[- ]?id\b|\.evals\b",
+        ],
+        weight=1.3,
+        official_reference="https://docs.claude.com/en/docs/claude-code; arXiv:2605.22166",
+    ),
+    SignalGroup(
+        key="telemetry",
+        title="Telemetry & Observability",
+        category=CATEGORY_HARNESS,
+        description=(
+            "Measurement of the harness: telemetry, scorecards, metrics, tracing, "
+            "drift incidents, audit logs, correlation IDs."
+        ),
+        keyword_patterns=[
+            r"\btelemetry\b",
+            r"\bobservability\b",
+            r"\bscorecard\b",
+            r"\bcorrelation id\b",
+            r"\btracing\b|\btraces\b",
+            r"\baudit log\b",
+            r"\bdrift incident\b",
+            r"\bsuccess[_ -]rate\b|\bcompletion[_ -]rate\b",
+        ],
+        weight=1.1,
+        official_reference="https://docs.claude.com/en/docs/claude-code; arXiv:2603.28052",
+    ),
+    SignalGroup(
+        key="maintenance_hygiene",
+        title="Anti-Drift Maintenance Hygiene",
+        category=CATEGORY_MAINTENANCE,
+        description=(
+            "Living-context practices: sentinel/canary drift checks, periodic "
+            "audits/detox, steward self-healing loops, decay schedules."
+        ),
+        keyword_patterns=[
+            r"\bsentinel\b",
+            r"\bcanary\b",
+            r"\bdrift detect(?:ion|ed)?\b",
+            r"\bstaleness\b|\bstale context\b",
+            r"\baudit (?:CLAUDE|AGENTS|the context|instruction)\b",
+            r"\bdetox\b",
+            r"\bsteward\b",
+            r"\bdecay schedule\b|\bdecay\b",
+            r"\bliving context\b",
+            r"\bself[- ]healing\b",
+            r"\bperiodic audit\b",
+        ],
+        weight=1.2,
+        official_reference="https://docs.claude.com/en/docs/claude-code/memory",
+    ),
+    # ---- L8 gate contributors -------------------------------------------------
+    SignalGroup(
+        key="dynamic_workflows",
+        title="Dynamic Workflows / Orchestration",
+        category=CATEGORY_ORCHESTRATION,
+        description=(
+            "External orchestration: dynamic workflows, JS orchestration scripts, "
+            "parallel subagents at scale, resumable background execution."
+        ),
+        keyword_patterns=[
+            r"\bdynamic workflows?\b",
+            r"\borchestration script\b",
+            r"\bparallel subagents?\b",
+            r"\bwho holds the plan\b",
+            r"\bresumable\b",
+            r"\bbackground execution\b",
+            r"\bfan[- ]out\b.{0,30}\bverif",
+            r"\bultracode\b",
+            r"\.claude/workflows\b",
+        ],
+        weight=1.3,
+        official_reference="https://code.claude.com/docs/en/workflows",
+    ),
+    SignalGroup(
+        key="plugins",
+        title="Plugin Distribution",
+        category=CATEGORY_PRIMITIVE,
+        description=(
+            "Team-scale distribution: plugin manifests / marketplaces bundling "
+            "skills, hooks, subagents, commands, and workflows."
+        ),
+        keyword_patterns=[
+            r"\.claude-plugin\b",
+            r"\bplugin manifest\b",
+            r"\bmarketplace\.json\b",
+            r"\bplugin marketplace\b",
+            r"\binstallable (?:plugin|package)\b",
+        ],
+        weight=1.0,
+        official_reference="https://docs.claude.com/en/docs/claude-code/plugins",
+    ),
+    # ---- Proxies & on-ramps ---------------------------------------------------
+    SignalGroup(
+        key="harness_engineering",
+        title="Harness Engineering Mindset",
+        category=CATEGORY_HARNESS,
+        description=(
+            "Explicit framing of the system around the model as the engineered "
+            "surface (prompt -> context -> harness progression)."
+        ),
+        keyword_patterns=[
+            r"\bharness engineering\b",
+            r"\bcontext engineering\b",
+            r"\bthe (?:system|machine|layer) around the model\b",
+            r"\bprompt engineering, context engineering\b",
+            r"\bfeedback loop\b",
+            r"\bone (?:agent|worktree) per (?:worktree|agent)\b",
+        ],
+        weight=0.9,
+        official_reference="arXiv:2603.28052; arXiv:2605.22166",
+    ),
+    SignalGroup(
+        key="curricula",
+        title="Curricula On-Ramps",
+        category=CATEGORY_CURRICULA,
+        description=(
+            "References to official learning on-ramps that teach context "
+            "engineering and production agent patterns."
+        ),
+        keyword_patterns=[
+            r"\bAnthropic Academy\b",
+            r"\bClaude Code 101\b",
+            r"\bAgent Skills course\b|\bIntroduction to Agent Skills\b",
+            r"\bModel Context Protocol course\b|\bIntro(?:duction)? to (?:the )?Model Context Protocol\b",
+            r"\b5[- ]?day AI Agents\b|\bGoogle .{0,20}AI Agents\b",
+            r"\bcontext engineering course\b",
+        ],
+        weight=0.7,
+        official_reference="https://www.anthropic.com/learn (Anthropic Academy); Google 5-Day AI Agents course",
+    ),
+]
+
+
+# Fast lookup by key.
+SIGNAL_GROUPS_BY_KEY: Dict[str, SignalGroup] = {g.key: g for g in SIGNAL_GROUPS}
+
+
+# =============================================================================
+# Level gate definitions (used by the scanner to rewire L6-L8)
+# =============================================================================
+# Each upper level requires a set of named requirements. A requirement maps to
+# either a signal key (content) or a structural-quality flag (filesystem). The
+# scanner resolves these against HarnessSignals + StructuralQuality.
+#
+# Requirement vocabulary (resolved in scanner._compute_signal_gates):
+#   structured_skills, hooks, subagents, verification           (L6)
+#   eval_loops, telemetry, maintenance_hygiene                  (L7, cumulative)
+#   orchestration, plugins, measured_outcomes                   (L8, cumulative)
+
+LEVEL_GATE_REQUIREMENTS: Dict[int, List[str]] = {
+    6: ["structured_skills", "hooks", "subagents", "verification"],
+    7: ["eval_loops", "telemetry", "maintenance_hygiene"],
+    8: ["orchestration", "plugins", "measured_outcomes"],
+}
+
+# Human-readable label for each gate requirement, used in reports/recommendations.
+GATE_REQUIREMENT_LABELS: Dict[str, str] = {
+    "structured_skills": "structured skills (YAML frontmatter or executable content)",
+    "hooks": "deterministic hooks (PreToolUse/PostToolUse/etc.)",
+    "subagents": "subagents (2+ agent definitions)",
+    "verification": "verification discipline (verify/adversarial/TDD/asserts)",
+    "eval_loops": "eval/regression loops (.evals or eval-suite references)",
+    "telemetry": "telemetry/observability (metrics, scorecards, tracing)",
+    "maintenance_hygiene": "anti-drift maintenance (sentinel/audit/steward/decay)",
+    "orchestration": "orchestration (.claude/workflows or dynamic-workflow patterns)",
+    "plugins": "plugin distribution (.claude-plugin manifest)",
+    "measured_outcomes": "measured outcomes (metrics/logs/success tracking)",
+}
+
+# Official reference for each gate requirement (for actionable recommendations).
+GATE_REQUIREMENT_REFERENCES: Dict[str, str] = {
+    "structured_skills": "https://docs.claude.com/en/docs/claude-code/skills",
+    "hooks": "https://docs.claude.com/en/docs/claude-code/hooks",
+    "subagents": "https://docs.claude.com/en/docs/claude-code/sub-agents",
+    "verification": "https://docs.claude.com/en/docs/claude-code/hooks",
+    "eval_loops": "https://docs.claude.com/en/docs/claude-code",
+    "telemetry": "https://docs.claude.com/en/docs/claude-code",
+    "maintenance_hygiene": "https://docs.claude.com/en/docs/claude-code/memory",
+    "orchestration": "https://code.claude.com/docs/en/workflows",
+    "plugins": "https://docs.claude.com/en/docs/claude-code/plugins",
+    "measured_outcomes": "https://docs.claude.com/en/docs/claude-code",
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "measure-ai-proficiency"
-version = "0.5.1"
+version = "0.6.0"
 description = "Measure AI coding proficiency based on context engineering artifacts"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -22,6 +22,11 @@ from measure_ai_proficiency.mcp_server import (
     validate_file_quality_handler,
     scan_github_repo_handler,
     scan_github_org_handler,
+    check_harness_orchestration_quality_handler,
+    scan_for_maintenance_hygiene_handler,
+    get_dynamic_workflow_recommendations_handler,
+    curricula_alignment_handler,
+    cheapest_primitive_decision_tree_report_handler,
 )
 from measure_ai_proficiency.scanner import RepoScanner, RepoScore
 
@@ -350,14 +355,15 @@ class TestGitHubHandlers:
             lambda: True
         )
 
-        # Create a mock RepoScore
-        scanner = RepoScanner(tmp_path)
-        mock_score = scanner.scan()
+        # github_scanner.scan_github_repo returns a TEMP DIR PATH (not a RepoScore).
+        # The handler wraps it with RepoScanner and cleans it up afterward.
+        repo_dir = tmp_path / "ghrepo"
+        repo_dir.mkdir()
+        (repo_dir / "CLAUDE.md").write_text("# Repo\n" + "x" * 200)
 
-        # Mock the scan_github_repo function
         monkeypatch.setattr(
             "measure_ai_proficiency.mcp_server.scan_github_repo",
-            lambda repo: mock_score
+            lambda repo: repo_dir
         )
 
         result = await scan_github_repo_handler("owner/repo")
@@ -367,6 +373,8 @@ class TestGitHubHandlers:
         assert "repo_name" in data
         assert "overall_level" in data
         assert "overall_score" in data
+        # Handler sets repo_path to the GitHub repo identifier
+        assert data["repo_path"] == "owner/repo"
 
     @pytest.mark.asyncio
     async def test_scan_github_repo_error(self, monkeypatch):
@@ -401,14 +409,14 @@ class TestGitHubHandlers:
             lambda: True
         )
 
-        # Create mock RepoScores
-        scanner = RepoScanner(tmp_path)
-        mock_score = scanner.scan()
+        # github_scanner.scan_github_org returns List[(repo_name, temp_dir_path)].
+        # The handler wraps each temp dir with RepoScanner and cleans them up.
+        d1 = tmp_path / "r1"; d1.mkdir(); (d1 / "CLAUDE.md").write_text("# r1\n" + "x" * 200)
+        d2 = tmp_path / "r2"; d2.mkdir(); (d2 / "CLAUDE.md").write_text("# r2\n" + "x" * 200)
 
-        # Mock the scan_github_org function to return a list of scores
         monkeypatch.setattr(
             "measure_ai_proficiency.mcp_server.scan_github_org",
-            lambda org, limit=None: [mock_score, mock_score]
+            lambda org, limit=None: [("owner/r1", d1), ("owner/r2", d2)]
         )
 
         result = await scan_github_org_handler("org-name", limit=10)
@@ -447,3 +455,101 @@ class TestGitHubHandlers:
         data = json.loads(result[0].text)
         assert "error" in data
         assert "org" in data
+
+
+def _make_rich_repo(root):
+    """Minimal rich fixture for the 2026 signal MCP tools."""
+    (root / "CLAUDE.md").write_text(
+        "# Project\nWe verify with adversarial review and clean-context verifiers.\n"
+        "Telemetry and observability scorecards. Audit CLAUDE.md for drift (sentinel canary).\n"
+        "Dynamic workflows orchestrate parallel subagents.\n"
+        "See the Anthropic Academy and the Google 5-day AI Agents course.\n" + "x" * 200
+    )
+    skill = root / ".claude" / "skills" / "foo"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: foo\ndescription: d\n---\n# Foo\nVerify outputs.\n")
+    (skill / "run.py").write_text("print('x')\n")
+    (root / ".claude" / "settings.json").write_text('{"hooks": {"PreToolUse": []}}\n')
+    wf = root / ".claude" / "workflows"
+    wf.mkdir(parents=True)
+    (wf / "m.md").write_text("# wf\n")
+
+
+class TestSignalTools:
+    """Tests for the 2026 context-engineering MCP tools."""
+
+    @pytest.mark.asyncio
+    async def test_check_harness_orchestration_quality(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "measure_ai_proficiency.mcp_server.get_current_repo", lambda: tmp_path
+        )
+        _make_rich_repo(tmp_path)
+        result = await check_harness_orchestration_quality_handler()
+        assert len(result) == 1 and result[0].type == "text"
+        data = json.loads(result[0].text)
+        assert "structural_quality" in data
+        assert "harness_signals" in data
+        assert "level_gates" in data
+        assert set(data["level_gates"].keys()) == {"L6", "L7", "L8"}
+
+    @pytest.mark.asyncio
+    async def test_scan_for_maintenance_hygiene(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "measure_ai_proficiency.mcp_server.get_current_repo", lambda: tmp_path
+        )
+        _make_rich_repo(tmp_path)
+        result = await scan_for_maintenance_hygiene_handler()
+        data = json.loads(result[0].text)
+        assert "maintenance_hygiene_detected" in data
+        assert data["maintenance_hygiene_detected"] is True
+        assert "signals" in data
+
+    @pytest.mark.asyncio
+    async def test_get_dynamic_workflow_recommendations(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "measure_ai_proficiency.mcp_server.get_current_repo", lambda: tmp_path
+        )
+        _make_rich_repo(tmp_path)
+        result = await get_dynamic_workflow_recommendations_handler()
+        data = json.loads(result[0].text)
+        assert data["workflows_present"] is True
+        assert "official_docs" in data
+        assert "code.claude.com/docs/en/workflows" in data["official_docs"]
+        assert isinstance(data["recommendations"], list)
+
+    @pytest.mark.asyncio
+    async def test_curricula_alignment(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "measure_ai_proficiency.mcp_server.get_current_repo", lambda: tmp_path
+        )
+        _make_rich_repo(tmp_path)
+        result = await curricula_alignment_handler()
+        data = json.loads(result[0].text)
+        assert data["curricula_referenced"] is True
+        assert "recommended_courses" in data
+        assert len(data["recommended_courses"]) >= 2
+
+    @pytest.mark.asyncio
+    async def test_cheapest_primitive_decision_tree(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "measure_ai_proficiency.mcp_server.get_current_repo", lambda: tmp_path
+        )
+        _make_rich_repo(tmp_path)
+        result = await cheapest_primitive_decision_tree_report_handler()
+        data = json.loads(result[0].text)
+        assert "decision_tree" in data
+        assert len(data["decision_tree"]) == 5
+        assert data["primitives_present"]["skills"] is True
+        assert data["primitives_present"]["workflows"] is True
+
+    @pytest.mark.asyncio
+    async def test_signal_tools_on_bare_repo(self, tmp_path, monkeypatch):
+        """Signal tools should not error on a bare repo and report gaps."""
+        monkeypatch.setattr(
+            "measure_ai_proficiency.mcp_server.get_current_repo", lambda: tmp_path
+        )
+        (tmp_path / "CLAUDE.md").write_text("# Project\n" + "x" * 100)
+        result = await scan_for_maintenance_hygiene_handler()
+        data = json.loads(result[0].text)
+        assert data["maintenance_hygiene_detected"] is False
+        assert len(data["recommendations"]) >= 1

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -753,3 +753,12 @@ class TestConciseness:
             Path(tmpdir, "CLAUDE.md").write_text("# Project\n" + ("word " * 300))
             score = RepoScanner(tmpdir).scan()
             assert score.validation.conciseness["CLAUDE.md"].threshold == 1500
+
+    def test_bloat_emits_actionable_recommendation(self):
+        """A bloated file should produce an anti-bloat recommendation with the audit rule."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "CLAUDE.md").write_text("# Project\n" + ("word " * 3500))
+            score = RepoScanner(tmpdir).scan()
+            joined = " ".join(score.recommendations)
+            assert "always-loaded line must change behavior" in joined
+            assert "AGENTS_FILE_GUIDANCE.md" in joined

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -705,3 +705,51 @@ class TestLevelGating:
             # L8 needs measured outcomes (metrics/logs), absent in the fixture
             assert score.signals.gates[8] is False
             assert "measured_outcomes" in score.signals.gate_missing[8]
+
+
+class TestConciseness:
+    """Tests for conciseness / context-hygiene (anti-bloat) detection."""
+
+    def test_bloated_always_on_file_flagged(self):
+        """A very large CLAUDE.md should be flagged as bloated with a penalty."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "CLAUDE.md").write_text("# Project\n" + ("word " * 3500))
+            score = RepoScanner(tmpdir).scan()
+            c = score.validation.conciseness["CLAUDE.md"]
+            assert c.is_always_on is True
+            assert c.is_bloated is True
+            assert score.validation.has_bloat is True
+            assert any(w.startswith("BLOAT:") for w in score.validation.warnings)
+            assert score.validation.validation_penalty > 0
+
+    def test_concise_always_on_file_not_flagged(self):
+        """A concise CLAUDE.md should not be flagged as bloated."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "CLAUDE.md").write_text("# Project\n" + ("word " * 120))
+            score = RepoScanner(tmpdir).scan()
+            c = score.validation.conciseness["CLAUDE.md"]
+            assert c.is_always_on is True
+            assert c.is_bloated is False
+            assert score.validation.has_bloat is False
+
+    def test_large_skill_exempt_from_bloat(self):
+        """On-demand skill bodies are exempt from the bloat threshold (progressive disclosure)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "CLAUDE.md").write_text("# Project\n" + "x" * 200)
+            skill = Path(tmpdir, ".claude", "skills", "foo")
+            skill.mkdir(parents=True)
+            (skill / "SKILL.md").write_text(
+                "---\nname: foo\ndescription: d\n---\n" + ("word " * 4000)
+            )
+            score = RepoScanner(tmpdir).scan()
+            rel = ".claude/skills/foo/SKILL.md"
+            assert rel in score.validation.conciseness
+            assert score.validation.conciseness[rel].is_always_on is False
+            assert score.validation.conciseness[rel].is_bloated is False
+
+    def test_bloat_threshold_configurable(self):
+        """The bloat threshold default is 1500 words."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "CLAUDE.md").write_text("# Project\n" + ("word " * 300))
+            score = RepoScanner(tmpdir).scan()
+            assert score.validation.conciseness["CLAUDE.md"].threshold == 1500

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -12,6 +12,45 @@ import pytest
 
 from measure_ai_proficiency import RepoScanner, RepoScore
 from measure_ai_proficiency.config import LEVELS
+from measure_ai_proficiency.scanner import LevelScore
+from measure_ai_proficiency.signals import SIGNAL_GROUPS, LEVEL_GATE_REQUIREMENTS
+
+
+def _make_rich_signal_repo(root: Path) -> None:
+    """Create a repo fixture exercising the 2026 signal + structural detectors."""
+    (root / "CLAUDE.md").write_text(
+        "# Project\n## Architecture\n"
+        "We practice verification with adversarial review and clean-context verifiers.\n"
+        "Run telemetry and observability scorecards. Audit CLAUDE.md for drift (sentinel canary).\n"
+        "Dynamic workflows orchestrate parallel subagents. Progressive disclosure for skills.\n"
+        "See the Anthropic Academy and the Google 5-day AI Agents course.\n"
+        "Choose the cheapest primitive first; skill vs subagent decisions matter.\n"
+        "This is harness engineering: the machine around the model, with a feedback loop.\n"
+        + "x" * 200
+    )
+    skill_dir = root / ".claude" / "skills" / "foo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: foo\ndescription: when to do foo\n---\n# Foo\nVerify and assert outputs.\n"
+    )
+    (skill_dir / "run.py").write_text("print('hi')\n")  # executable content
+    agents_dir = root / ".claude" / "agents"
+    agents_dir.mkdir(parents=True)
+    (agents_dir / "reviewer.md").write_text("# reviewer\n")
+    (agents_dir / "planner.md").write_text("# planner\n")
+    hooks_dir = root / ".claude" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "format.sh").write_text("echo hi\n")
+    (root / ".claude" / "settings.json").write_text('{"hooks": {"PreToolUse": []}}\n')
+    wf_dir = root / ".claude" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "migrate.md").write_text("# migration workflow\n")
+    plugin_dir = root / ".claude-plugin"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.json").write_text('{"name": "x"}\n')
+    evals_dir = root / ".evals" / "cases"
+    evals_dir.mkdir(parents=True)
+    (evals_dir / "EVAL-001.md").write_text("---\neval-id: EVAL-001\n---\n# case\n")
 
 
 class TestRepoScanner:
@@ -533,3 +572,136 @@ Use `/path/to/file` and `~/config/file`.
             assert score.cross_references.total_count == 0
             assert score.cross_references.source_files_scanned == 0
             assert score.cross_references.bonus_points == 0
+
+
+class TestSignals:
+    """Tests for 2026 context-engineering signal detection."""
+
+    def test_signals_present_on_scan(self):
+        """Every scan should attach a HarnessSignals object with gate keys 6-8."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "CLAUDE.md").write_text("# Project\n" + "x" * 200)
+            score = RepoScanner(tmpdir).scan()
+            assert score.signals is not None
+            assert set(score.signals.gates.keys()) == {6, 7, 8}
+            assert 0.0 <= score.signals.bonus_points <= 10.0
+
+    def test_rich_repo_matches_all_signal_groups(self):
+        """A rich fixture should match every registered signal group."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _make_rich_signal_repo(Path(tmpdir))
+            score = RepoScanner(tmpdir).scan()
+            matched = set(score.signals.matched_keys)
+            expected = {g.key for g in SIGNAL_GROUPS}
+            assert expected.issubset(matched), f"missing: {expected - matched}"
+
+    def test_structural_quality_detection(self):
+        """Structural detection should find frontmatter, executable content, hooks, etc."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _make_rich_signal_repo(Path(tmpdir))
+            sq = RepoScanner(tmpdir).scan().signals.structural
+            assert sq.skills_count >= 1
+            assert sq.skills_with_frontmatter >= 1
+            assert sq.skills_with_executable_content >= 1
+            assert sq.skills_with_verification >= 1
+            assert sq.hooks_present is True
+            assert "PreToolUse" in sq.hook_events
+            assert sq.subagents_count >= 2
+            assert sq.workflows_present is True
+            assert sq.plugins_present is True
+            assert sq.skills_structured is True
+            assert 0.0 <= sq.structural_score <= 10.0
+
+    def test_verification_signal_keyword(self):
+        """Verification keywords in CLAUDE.md should set the verification signal."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "CLAUDE.md").write_text(
+                "# Project\nAlways verify with adversarial refutation and asserts.\n" + "x" * 200
+            )
+            score = RepoScanner(tmpdir).scan()
+            assert score.signals.hits["verification"].matched is True
+
+    def test_no_false_positive_signals_on_bare_repo(self):
+        """A bare CLAUDE.md should not trip orchestration/plugin/maintenance signals."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "CLAUDE.md").write_text("# Project\nA simple project.\n" + "x" * 100)
+            score = RepoScanner(tmpdir).scan()
+            assert score.signals.hits["dynamic_workflows"].matched is False
+            assert score.signals.hits["plugins"].matched is False
+            assert score.signals.hits["maintenance_hygiene"].matched is False
+
+    def test_signal_bonus_adds_to_score(self):
+        """Signal bonus should be reflected in overall_score (vs a bare repo)."""
+        with tempfile.TemporaryDirectory() as bare, tempfile.TemporaryDirectory() as rich:
+            Path(bare, "CLAUDE.md").write_text("# Project\n" + "x" * 200)
+            bare_score = RepoScanner(bare).scan()
+            _make_rich_signal_repo(Path(rich))
+            rich_score = RepoScanner(rich).scan()
+            assert rich_score.signals.bonus_points > bare_score.signals.bonus_points
+
+
+class TestLevelGating:
+    """Tests for the L6-L8 signal-gate rewire."""
+
+    def _full_coverage_levels(self):
+        """Synthetic level scores with high coverage for levels 3-8."""
+        scores = {}
+        for level in range(1, 9):
+            scores[level] = LevelScore(
+                level=level,
+                name=f"Level {level}",
+                description="",
+                total_patterns=10,
+                coverage_percent=50.0,
+            )
+        return scores
+
+    def test_gate_caps_level_when_signal_missing(self):
+        """A failing L6 gate must cap the achieved level at 5 despite full coverage."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scanner = RepoScanner(tmpdir)
+            level_scores = self._full_coverage_levels()
+            gates = {6: False, 7: False, 8: False}
+            capped = scanner._calc_level_with_thresholds(
+                level_scores, scanner.DEFAULT_THRESHOLDS, gates
+            )
+            assert capped == 5
+
+    def test_no_gates_reaches_level_8(self):
+        """Without gates (backward compatible), full coverage reaches level 8."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scanner = RepoScanner(tmpdir)
+            level_scores = self._full_coverage_levels()
+            assert scanner._calc_level_with_thresholds(
+                level_scores, scanner.DEFAULT_THRESHOLDS, None
+            ) == 8
+
+    def test_l6_gate_passes_l7_blocks(self):
+        """If L6 gate passes but L7 fails, level caps at 6."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scanner = RepoScanner(tmpdir)
+            level_scores = self._full_coverage_levels()
+            gates = {6: True, 7: False, 8: False}
+            assert scanner._calc_level_with_thresholds(
+                level_scores, scanner.DEFAULT_THRESHOLDS, gates
+            ) == 6
+
+    def test_compute_gates_reports_missing_requirements(self):
+        """A bare repo should report all L6 requirements as missing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "CLAUDE.md").write_text("# Project\n" + "x" * 200)
+            score = RepoScanner(tmpdir).scan()
+            missing_6 = set(score.signals.gate_missing[6])
+            assert set(LEVEL_GATE_REQUIREMENTS[6]).issubset(missing_6)
+            assert score.signals.gates[6] is False
+
+    def test_rich_repo_satisfies_l6_and_l7_gates(self):
+        """The rich fixture should satisfy the L6 and L7 signal gates."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _make_rich_signal_repo(Path(tmpdir))
+            score = RepoScanner(tmpdir).scan()
+            assert score.signals.gates[6] is True
+            assert score.signals.gates[7] is True
+            # L8 needs measured outcomes (metrics/logs), absent in the fixture
+            assert score.signals.gates[8] is False
+            assert "measured_outcomes" in score.signals.gate_missing[8]

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,75 @@
+# TODO — June 2026 Context-Engineering Signal Enhancements
+
+**Goal:** Evolve the scanner from presence detection toward structural quality,
+harness/orchestration maturity, maintenance hygiene, verification, and curricula
+signals. **Rewire L6–L8** so they require these signals (not just file coverage).
+All detection grounded in **official documentation only** (no X handles).
+
+## Decisions (locked with user)
+- **Scoring:** Rewire L6–L8 ladder — signals gate the level number. Full primitive
+  + harness gating (file presence AND content signals both required). Plus a
+  bounded signal bonus to overall_score.
+- **Gates:**
+  - L6 ← structured skills + hooks + subagents + verification
+  - L7 ← L6 + eval-loops + telemetry + anti-drift (maintenance hygiene)
+  - L8 ← L7 + orchestration (.claude/workflows) + plugins + measured outcomes
+- **Faithfulness:** Adapt & improve — add the docs' #1 signals (verification, hooks)
+  the proposal omitted; scope runtime concepts to detectable proxies; curricula light.
+- **Scope:** Code + tests + evals + docs in this repo; update personalclaude wiki; file GitHub issue/PR.
+
+## Grounding (official sources only)
+- Claude Code docs: https://docs.claude.com/en/docs/claude-code
+- Dynamic Workflows: https://code.claude.com/docs/en/workflows
+- Hooks / Skills / Sub-agents / Plugins / MCP: docs.claude.com/en/docs/claude-code/{hooks,skills,sub-agents,plugins,mcp}
+- Agent Skills standard: https://agentskills.io
+- Harness research: arXiv:2603.28052 (Meta-Harness), arXiv:2605.22166 (Life-Harness)
+- Anthropic Academy + Google 5-day AI Agents course (Day 3 Context engineering)
+
+## Plan
+- [x] 1. config.py — added `.claude/workflows`, plugin manifests, `.evals` artifacts; refreshed L6–L8 descriptions.
+- [x] 2. signals.py (NEW) — `SignalGroup` registry (10 groups) + `LEVEL_GATE_REQUIREMENTS`, official references only.
+- [x] 3. scanner.py — SignalHit/StructuralQuality/HarnessSignals; `_analyze_signals` + `_detect_structural_quality` + `_compute_signal_gates`; **rewired** L6–L8 gating in `_calc_level_with_thresholds`; signal bonus; signal-gap recommendations.
+- [x] 4. reporter.py — signals in all 4 reporters' single report + `_score_to_dict`; CSV columns; markdown multi gate column.
+- [x] 5. mcp_server.py — 5 new tools.
+- [x] 6. github_scanner.py — artifact-dir special-casing for remote scans.
+- [x] 7. __init__.py — exported new public types; bumped to 0.6.0.
+- [x] 8. tests — TestSignals (6) + TestLevelGating (5) + 6 MCP signal-tool tests.
+- [x] 9. .evals — EVAL-007..012 + EVAL_INDEX.md.
+- [x] 10. docs — CLAUDE.md, README.md, docs/MCP.md, new docs/SIGNALS.md.
+- [x] 11. Verify — `pytest tests/` → 137 passed; eval grep-checks 6/6.
+- [x] 12. wiki — personalclaude index.md updated.
+- [ ] 13. GitHub — branch, commit, push, open PR + tracking issue.
+- [x] 14. simplify-and-harden review pass (3 parallel auditors) — findings triaged + fixed.
+
+## Review
+
+**Outcome:** Implemented the June 2026 enhancement. The scanner now detects 10
+context-engineering signals (grounded only in official docs) and **rewires L6–L8**
+so they require signals + file coverage, not coverage alone. Surfaced across all
+reporters, JSON/CSV, and 5 new MCP tools. 137 tests pass; 6 eval cases guard the
+new signals/gating.
+
+**Key design adaptations (vs. the proposal):**
+- The proposal's literal `LevelConfig(category=, patterns=, maturity_impact=, examples=)`
+  does not match the real dataclass; signals live in a dedicated `signals.py` module
+  instead of bolted onto level configs.
+- Added the two signals the proposal omitted but the official-doc research ranks #1:
+  **verification** and **hooks** (both are L6 gate requirements).
+- Scoped runtime-only concepts (dynamic workflows, harness engineering) to
+  statically-detectable proxies, per the docs' "static scans can't measure runtime" caveat.
+- No X/social-media handles in any detection pattern or recommendation — official sources only.
+
+**Adversarial audit (simplify + harden + spec) findings fixed:**
+- subagents gate aligned to `>= 2` (matched the human-facing label).
+- verification gate decoupled from `.evals` infra (was conflated with L7 eval_loops).
+- `measured_outcomes` surfaced as a visible signal hit (was gate-only).
+- de-duplicated `_has_eval_infra()` call; bounded `_concat_instruction_text` file reads.
+- memoized `_find_instruction_files` per scan (removes 3 redundant filesystem walks).
+- **Drive-by fix:** pre-existing crash in `scan_github_repo_handler` / `scan_github_org_handler`
+  (they passed raw temp-dir Paths/tuples to `format_score_result`; now wrap with
+  `RepoScanner` + clean up temp dirs + fixed the `limit`-as-`verbose` positional bug).
+  Updated 2 tests that had been mocking the buggy contract.
+- Added a path-traversal guard and a JSON-decode guard in `github_scanner.py`.
+
+**Deferred (pre-existing, out of scope):** tool-name dict duplication, a couple of
+redundant inner imports, `ContentQuality` rebuild ergonomics — noted, not changed.


### PR DESCRIPTION
Closes #291

## What & why

Evolves the scanner from file-presence detection toward **structural quality, verification, harness/orchestration maturity, and maintenance hygiene**, and **rewires Levels 6–8** so they require these 2026 context-engineering signals *and* file coverage — not coverage alone.

All detection is grounded **only in official documentation** (Claude Code docs, `code.claude.com/docs/en/workflows`, the harness research papers, Anthropic Academy, Google 5-Day AI Agents). No social-media handles in any pattern or recommendation. See `docs/SIGNALS.md`.

## Changes

**New `signals.py`** — 10 `SignalGroup`s + `LEVEL_GATE_REQUIREMENTS` (verification, hooks, primitive discipline, eval loops, telemetry, maintenance hygiene, dynamic workflows, plugins, harness engineering, curricula), each with an official reference.

**`scanner.py`**
- `StructuralQuality` across the 6 primitives; `_analyze_signals`, `_detect_structural_quality`, `_compute_signal_gates`.
- **L6–L8 gating** wired into `_calc_level_with_thresholds` (backward compatible — `signals=None` ⇒ no gating).
  - L6 ← structured skills + hooks + subagents(≥2) + verification
  - L7 ← L6 + eval loops + telemetry + anti-drift maintenance hygiene
  - L8 ← L7 + orchestration (`.claude/workflows`) + plugins + measured outcomes
- Bounded signal bonus (0–10) + signal-gap recommendations with official links.
- Memoized `_find_instruction_files` per scan (removes redundant filesystem walks).

**`reporter.py`** — signals section in all four single-repo reports + `_score_to_dict`; new CSV columns; markdown multi-repo gate column.

**`mcp_server.py`** — 5 new tools: `check_harness_orchestration_quality`, `scan_for_maintenance_hygiene`, `get_dynamic_workflow_recommendations`, `curricula_alignment`, `cheapest_primitive_decision_tree_report`.

**`config.py`** — `.claude/workflows`, plugin manifests, `.evals` artifacts added to L7/L8; refreshed L6–L8 descriptions.
**`github_scanner.py`** — remote scans now pull the new artifact dirs; added path-traversal + JSON-decode guards.

### Drive-by fix (pre-existing crash, same file)
`scan_github_repo_handler` / `scan_github_org_handler` passed raw temp-dir `Path`/tuple returns from `github_scanner` directly to `format_score_result` (expects a `RepoScore`) → `AttributeError` on every remote-scan MCP call, plus leaked temp dirs and a `limit`-passed-as-`verbose` positional bug. Now mirror `__main__.py`: wrap with `RepoScanner`, set repo name, clean up temp dirs. Updated the 2 tests that had been mocking the buggy contract.

## Verification

- `pytest tests/` → **137 passed** (28 new: `TestSignals`, `TestLevelGating`, `TestSignalTools`).
- Eval grep-checks **6/6** (EVAL-007..012 guard the new signals + the gating rewire).
- Adversarial audit (simplify + harden + spec auditors) run; all real findings fixed.
- **Dogfood** (this repo): Level 5, all 9 keyword signals matched, **L6 ✓ / L7 ✓ / L8 ✗** (missing plugins + measured outcomes) — capped at L5 by Fleet-Infrastructure *file* coverage, with the harness signals correctly reported as present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
