### PR TITLE
feat: context efficacy proving harness (--prove); v0.7.0

### DIFF
--- a/.evals/EVAL_INDEX.md
+++ b/.evals/EVAL_INDEX.md
@@ -18,6 +18,9 @@ Managed by `self-improvement-meta` (creates eval cases for promoted learnings) a
 | [EVAL-011](.evals/cases/EVAL-011.md) | June 2026 signal enhancement — curricula on-ramps | `measure_ai_proficiency/signals.py` | grep-check | `key="curricula"` |
 | [EVAL-012](.evals/cases/EVAL-012.md) | June 2026 rewire — L6-L8 require context-engineering signals, not file coverage alone | `measure_ai_proficiency/scanner.py` | grep-check | `def _compute_signal_gates` |
 | [EVAL-013](.evals/cases/EVAL-013.md) | June 2026 — conciseness/anti-bloat for always-on files (CLAUDE.md/AGENTS.md) | `measure_ai_proficiency/scanner.py` | grep-check | `def _analyze_conciseness` |
+| [EVAL-014](.evals/cases/EVAL-014.md) | v0.7.0 — efficacy proving engine present | `measure_ai_proficiency/efficacy.py` | grep-check | `class EfficacyAnalyzer` |
+| [EVAL-015](.evals/cases/EVAL-015.md) | v0.7.0 security — exec hard-blocked on remote repos | `measure_ai_proficiency/efficacy.py` | grep-check | `bool(execute) and not is_remote` |
+| [EVAL-016](.evals/cases/EVAL-016.md) | v0.7.0 security — sandbox never uses shell=True | `measure_ai_proficiency/efficacy.py` | grep-check (not_found) | `shell=True` |
 
 ## Retired cases
 

--- a/.evals/cases/EVAL-014.md
+++ b/.evals/cases/EVAL-014.md
@@ -1,0 +1,34 @@
+---
+eval-id: EVAL-014
+source-learning: v0.7.0 efficacy harness — the proving engine must stay present
+target: measure_ai_proficiency/efficacy.py
+method: grep-check
+expect: found
+pattern: "class EfficacyAnalyzer"
+created: 2026-06-02
+last-run: 2026-06-02
+last-result: pass
+---
+
+# EVAL-014: efficacy proving engine is present
+
+## Scenario
+
+v0.7.0 turns the scanner from a context linter into a context proving harness: a
+`--prove` pass that runs the repo's artifacts and reports a report-only Efficacy Score.
+
+## Regression path
+
+`measure_ai_proficiency/efficacy.py` defines `EfficacyAnalyzer` (commands/hooks/context-budget provers).
+
+## Check
+
+`efficacy.py` must contain `class EfficacyAnalyzer`.
+
+## Pass condition
+
+`grep -qF 'class EfficacyAnalyzer' measure_ai_proficiency/efficacy.py` exits 0.
+
+## Fail condition
+
+The efficacy engine was removed.

--- a/.evals/cases/EVAL-015.md
+++ b/.evals/cases/EVAL-015.md
@@ -1,0 +1,34 @@
+---
+eval-id: EVAL-015
+source-learning: v0.7.0 security invariant — execution must be hard-blocked on remote/GitHub-scanned repos
+target: measure_ai_proficiency/efficacy.py
+method: grep-check
+expect: found
+pattern: "bool(execute) and not is_remote"
+created: 2026-06-02
+last-run: 2026-06-02
+last-result: pass
+---
+
+# EVAL-015: efficacy execution is hard-blocked on remote repos
+
+## Scenario
+
+`--prove-exec` runs repo-defined code. Running it against a remote/GitHub-scanned repo
+(untrusted) would be dangerous, so EfficacyAnalyzer forces execution off when is_remote.
+
+## Regression path
+
+The analyzer computes `self.execute = bool(execute) and not is_remote`.
+
+## Check
+
+`efficacy.py` must contain the literal `bool(execute) and not is_remote`.
+
+## Pass condition
+
+`grep -qF 'bool(execute) and not is_remote' measure_ai_proficiency/efficacy.py` exits 0.
+
+## Fail condition
+
+The remote-exec block was removed; remote scans could execute untrusted repo code.

--- a/.evals/cases/EVAL-016.md
+++ b/.evals/cases/EVAL-016.md
@@ -1,0 +1,34 @@
+---
+eval-id: EVAL-016
+source-learning: v0.7.0 security invariant — the sandbox must never use shell=True
+target: measure_ai_proficiency/efficacy.py
+method: grep-check
+expect: not_found
+pattern: "shell=True"
+created: 2026-06-02
+last-run: 2026-06-02
+last-result: pass
+---
+
+# EVAL-016: efficacy sandbox never uses shell=True
+
+## Scenario
+
+The executor runs repo-defined commands. Using `shell=True` would open a shell-injection
+vector; commands must run from an argv list only.
+
+## Regression path
+
+`_run_sandboxed` calls `subprocess.run(argv, ...)` with no `shell=True`.
+
+## Check
+
+`efficacy.py` must NOT contain `shell=True`.
+
+## Pass condition
+
+`grep -qF 'shell=True' measure_ai_proficiency/efficacy.py` exits NON-zero (pattern absent).
+
+## Fail condition
+
+`shell=True` was introduced — a shell-injection vector via repo-defined commands.

--- a/.github/workflows/efficacy.yml
+++ b/.github/workflows/efficacy.yml
@@ -36,8 +36,13 @@ jobs:
             const fs = require('fs');
             const marker = '<!-- context-efficacy -->';
             let report = '';
-            try { report = fs.readFileSync('efficacy_report.md', 'utf8'); } catch (e) { report = '_efficacy report unavailable_'; }
-            const body = `${marker}\n## 🔬 Context Efficacy (resolve-only)\n\n${report}`;
+            try { report = fs.readFileSync('efficacy_report.md', 'utf8'); } catch (e) { report = 'efficacy report unavailable'; }
+            // SECURITY: the report is generated from untrusted PR-branch content. Render it
+            // as LITERAL text inside a code fence (never as Markdown/HTML), neutralize any
+            // fence-breakout sequences, and cap the size — prevents content injection into
+            // this PR comment.
+            report = report.replace(/```/g, '`​``').slice(0, 60000);
+            const body = `${marker}\n## 🔬 Context Efficacy (resolve-only)\n\n\`\`\`text\n${report}\n\`\`\``;
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
             const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });

--- a/.github/workflows/efficacy.yml
+++ b/.github/workflows/efficacy.yml
@@ -1,0 +1,49 @@
+name: Context Efficacy (PR)
+
+# Runs the deterministic, RESOLVE-ONLY efficacy pass (--prove) on PRs and posts the
+# result as a sticky comment. No repo code is executed (no --prove-exec in CI).
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  efficacy:
+    name: Prove context efficacy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install
+        run: pip install .
+
+      - name: Run efficacy pass (resolve-only)
+        run: measure-ai-proficiency --prove --format markdown > efficacy_report.md || true
+
+      - name: Upsert PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- context-efficacy -->';
+            let report = '';
+            try { report = fs.readFileSync('efficacy_report.md', 'utf8'); } catch (e) { report = '_efficacy report unavailable_'; }
+            const body = `${marker}\n## 🔬 Context Efficacy (resolve-only)\n\n${report}`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ The tool scans repositories for files like `CLAUDE.md`, `.cursorrules`, `.github
 - 8-level maturity scoring aligned with Steve Yegge's model
 - **2026 context-engineering signals** (verification, hooks, eval loops, telemetry, anti-drift maintenance hygiene, dynamic-workflow orchestration, plugins, harness engineering, curricula) — grounded in official docs only; see `docs/SIGNALS.md`
 - **L6-L8 are signal-gated**: reaching those levels requires the matching primitives/harness/orchestration signals AND file coverage (not coverage alone)
+- **Context efficacy proving (v0.7.0, `--prove`)**: a report-only Efficacy Score that PROVES artifacts work (documented commands resolve, hooks wired, context token budget); `--prove-exec` runs them in a hardened sandbox (local only, never remote). See `docs/EFFICACY.md`
 - Structural quality scoring of the 6 primitives (skill frontmatter/executable content/verification, hook events, subagents, workflows, plugins)
 - Cross-reference detection between AI instruction files
 - Content quality evaluation (sections, commands, constraints)
@@ -109,6 +110,7 @@ The project now includes an **MCP (Model Context Protocol) server** that makes A
 - `get_dynamic_workflow_recommendations` - Adopt Dynamic Workflows + verification (scoped to detectable artifacts)
 - `curricula_alignment` - Official learning on-ramp references (Anthropic Academy, Google 5-Day AI Agents)
 - `cheapest_primitive_decision_tree_report` - Primitive decision discipline (Skill → MCP → Subagent → Hook → Plugin)
+- `prove_efficacy` - Prove the repo's artifacts work: report-only Efficacy Score + per-artifact evidence (resolve-only by default; sandboxed exec opt-in, never remote)
 
 **Configuration:** Add to `.mcp.json`:
 ```json
@@ -160,7 +162,8 @@ measure_ai_proficiency/
 ├── mcp_server.py      # MCP server for AI assistant integration
 ├── config.py          # Level definitions and file patterns
 ├── signals.py         # 2026 context-engineering signal registry + L6-8 gate requirements (official-doc grounded)
-├── scanner.py         # Repository scanning logic + cross-reference detection + signal analysis + L6-8 gating
+├── efficacy.py        # v0.7.0 context efficacy proving harness (--prove): commands/hooks provers + context-budget + hardened sandbox
+├── scanner.py         # Repository scanning logic + cross-reference detection + signal analysis + L6-8 gating + RepoScanner.prove()
 ├── github_scanner.py  # GitHub CLI integration for remote scanning
 ├── reporter.py        # Output formatting (terminal, JSON, markdown, CSV)
 └── repo_config.py     # Repository configuration and tool auto-detection
@@ -225,6 +228,7 @@ pytest tests/ -v
 - Add new quality indicators: Edit `QUALITY_PATTERNS` in `measure_ai_proficiency/scanner.py`
 - Add a new 2026 signal: Add a `SignalGroup` to `SIGNAL_GROUPS` in `measure_ai_proficiency/signals.py` (keyword patterns + weight + an **official** reference). To gate a level, add its key to `LEVEL_GATE_REQUIREMENTS` and resolve it in `RepoScanner._compute_signal_gates`. Add a regression eval under `.evals/cases/`. See `docs/SIGNALS.md`.
 - Adjust L6-8 gating: Edit `LEVEL_GATE_REQUIREMENTS` (signals.py) and `_compute_signal_gates` (scanner.py). Levels 6-8 require signals AND file coverage; the `gates` dict flows into `_calc_level_with_thresholds`.
+- Add an efficacy prover: add a `_prove_*` method to `EfficacyAnalyzer` in `measure_ai_proficiency/efficacy.py` and call it from `run()`. Execution MUST go through `_run_sandboxed` (allowlist + scrubbed env + timeout, never `shell=True`) and respect the remote-exec block. Add a regression eval. See `docs/EFFICACY.md` (threat model).
 - Add new MCP tools: Add handler in `measure_ai_proficiency/mcp_server.py`, update `list_tools()` and `call_tool()`
 - Writing/auditing agents files (CLAUDE.md/AGENTS.md): keep them concise and behavioral — every always-loaded line must change behavior or be cut. See `docs/AGENTS_FILE_GUIDANCE.md`.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This tool scans repositories for context engineering artifacts and calculates a 
 
 Since v0.6.0 it also detects **2026 context-engineering signals** — verification, hooks, eval loops, telemetry, anti-drift maintenance hygiene, dynamic-workflow orchestration, plugins, and harness engineering — and uses them to **gate Levels 6-8** (file coverage alone is no longer enough). It also flags **bloated always-on files** (a permanent context tax). See **[docs/SIGNALS.md](docs/SIGNALS.md)** and **[docs/AGENTS_FILE_GUIDANCE.md](docs/AGENTS_FILE_GUIDANCE.md)** (how to write concise, behavioral CLAUDE.md/AGENTS.md). All detection is grounded in official documentation.
 
+Since v0.7.0 it can also **prove** what your context actually *does*, not just what exists: `measure-ai-proficiency --prove` runs a report-only **efficacy** pass (do documented commands resolve? are hooks wired? what's the always-on token budget?) and reports a separate Efficacy Score with reproducible green/red evidence — resolve-only by default; `--prove-exec` runs commands/hooks in a hardened sandbox (local repos only). See **[docs/EFFICACY.md](docs/EFFICACY.md)**.
+
 ## Quick Start
 
 ```bash
@@ -73,6 +75,7 @@ Ask your AI assistant:
 - `get_dynamic_workflow_recommendations` - Adopt Dynamic Workflows + verification
 - `curricula_alignment` - Official learning on-ramp references
 - `cheapest_primitive_decision_tree_report` - Primitive decision discipline
+- `prove_efficacy` - Prove the repo's artifacts work (Efficacy Score; resolve-only or sandboxed)
 
 📖 **[Full MCP Documentation](docs/MCP.md)** - Setup, examples, troubleshooting
 

--- a/docs/EFFICACY.md
+++ b/docs/EFFICACY.md
@@ -1,0 +1,80 @@
+# Context Efficacy Proving Harness (`--prove`)
+
+`measure-ai-proficiency` (v0.7.0+) can **prove** what a repo's AI artifacts actually
+*do*, not just that they exist — and reports it as a separate, **report-only**
+Efficacy Score (0–100) with per-artifact green/red evidence and a reproducing command.
+
+It never changes the Proficiency Score or maturity level. Efficacy answers a different
+question: *"of the context you have, how much demonstrably works?"*
+
+```bash
+measure-ai-proficiency --prove          # resolve-only: runs NO repo code
+measure-ai-proficiency --prove-exec     # also executes commands/hooks in a sandbox (local only)
+measure-ai-proficiency --prove --context-window 1000000   # custom budget window
+```
+
+## What it proves (MVP)
+
+| Prover | Resolve-only (`--prove`) | With `--prove-exec` |
+|--------|--------------------------|---------------------|
+| **Commands** | Documented CLI commands resolve on `PATH` (`command -v`) | Also runs the allowlisted `<cmd> --help` probe in the sandbox (never the documented args) |
+| **Hooks** | Hooks are wired in `settings.json` / present in `.claude/hooks`, and referenced scripts exist | (same — **hooks are validate-only and never executed**; running arbitrary hook command strings safely needs a container) |
+| **Context budget** | Always-on token footprint (instruction files + skill frontmatter), % of a reference window, efficiency factor — **deterministic, never executes** | (same) |
+
+Each check reports `pass` / `fail` / `skip` with evidence and a copy-pasteable
+reproducing command. **Absence isn't penalized** — a prover with nothing to prove is
+excluded from the score (presence is the Proficiency score's job; efficacy is about
+whether what *exists* works).
+
+## Security model
+
+`--prove-exec` runs repo-defined code, so repo content is treated as **untrusted input**.
+
+- **Opt-in, twice.** Nothing executes under `--prove` (resolve-only). Execution requires
+  the explicit `--prove-exec` flag.
+- **Never on remote.** Execution is **hard-blocked** for `--github-repo` / `--github-org`
+  scans (and the MCP tool never executes remote). The CLI prints a notice and downgrades
+  to resolve-only.
+- **Default scan unchanged.** A normal scan (no `--prove`) computes no efficacy and runs
+  nothing new.
+
+### Executor hardening (`efficacy._run_sandboxed`)
+
+| Control | Implementation |
+|---------|----------------|
+| No shell injection | Commands run from an `argv` **list**; never `shell=True`. |
+| Command allowlist | Only basenames in `DEFAULT_COMMAND_ALLOWLIST` (build/test/lint *nouns* — no shells/interpreters) execute, and only the fixed `<cmd> --help` probe runs (never documented args). The probe always runs the `PATH`-resolved binary for the basename. A repo's `.ai-proficiency.yaml` can only **narrow** the allowlist (intersection), never widen it. |
+| Scrubbed env | Only `PATH`/`LANG`/`TMPDIR`/… pass through. `HOME` is **replaced with a throwaway temp dir** per call so user credential files (`~/.npmrc`, `~/.pypirc`, `~/.m2`, …) are never read. No inherited tokens/secrets. |
+| Hooks never execute | Hook command strings are arbitrary untrusted shell, so hooks are **validate-only** (wiring + contained script existence) even under `--prove-exec`. |
+| Timeout | Per-call `_EXEC_TIMEOUT_SECONDS` (15s); timeouts are reported as `fail`. |
+| Output cap | stdout/stderr truncated to `_OUTPUT_CAP_BYTES`. |
+| Path containment | Hook-referenced scripts are resolved and confined strictly inside the repo dir. |
+
+### Known limitation
+
+True **network isolation** requires a container/namespace, which is out of scope for the
+MVP. We mitigate with the allowlist, scrubbed env, timeouts, and output caps, and call it
+out here rather than imply the sandbox is airtight. Run `--prove-exec` only on repos you
+trust; CI runs resolve-only.
+
+## Surfaces
+
+- **CLI:** `--prove` / `--prove-exec` / `--context-window` (renders in all four formats; new CSV columns `efficacy_score`, `always_on_tokens`, `efficacy_executed`).
+- **MCP:** `prove_efficacy` tool (resolve-only by default; `execute` arg honored for the local repo only) — lets an assistant prove its own setup works.
+- **CI:** `.github/workflows/efficacy.yml` runs the resolve-only pass on PRs and posts a sticky comment.
+
+## Scoring
+
+Report-only Efficacy Score (0–100) = mean of the available sub-scores (command
+resolution rate, hook wiring/exec rate, context-budget efficiency factor). It is shown
+*beside* the Proficiency Score and never alters the level.
+
+## Deferred
+
+Skills smoke-test prover; an LLM **behavior-change probe** (run a model turn with/without
+a rule and measure whether output changes — the automated *"what would go wrong if this
+line wasn't here?"*); and efficacy **gating** L6+ once the signal is trusted.
+
+See [SIGNALS.md](SIGNALS.md) for the (presence/structure) signal layer and
+[AGENTS_FILE_GUIDANCE.md](AGENTS_FILE_GUIDANCE.md) for the conciseness guidance the
+context-budget prover quantifies.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -77,7 +77,7 @@ After updating the configuration, restart Claude Code to load the MCP server.
 
 ## Available Tools
 
-The MCP server provides 12 tools for AI proficiency analysis (7 core + 5 for the 2026 context-engineering signals — see [SIGNALS.md](SIGNALS.md)):
+The MCP server provides 13 tools for AI proficiency analysis (7 core + 5 for the 2026 context-engineering signals — see [SIGNALS.md](SIGNALS.md) — + 1 efficacy prover, see [EFFICACY.md](EFFICACY.md)):
 
 ### 1. `scan_current_repo`
 
@@ -268,6 +268,15 @@ Check whether the repo references official learning on-ramps.
 Return the cheapest-primitive-first decision tree (Skill → MCP → Subagent → Hook → Plugin/Workflow) and which primitives the repo actually uses.
 
 **Returns:** `decision_tree`, `rule`, `primitives_present`, and the decision-discipline signal.
+
+### 13. `prove_efficacy`
+
+Prove what the current repo's AI artifacts actually do (report-only). See [EFFICACY.md](EFFICACY.md).
+
+**Parameters:**
+- `execute` (boolean, default false): run commands/hooks in a hardened sandbox (local repo only). False = resolve-only (no repo code executed).
+
+**Returns:** `efficacy_score`, `executed`, per-prover `checks` (status + evidence + reproduce_cmd), and `context_budget` (always-on token footprint). Never changes the proficiency level/score.
 
 ## Usage Examples
 

--- a/docs/plans/plan-298-context-efficacy-harness.md
+++ b/docs/plans/plan-298-context-efficacy-harness.md
@@ -1,0 +1,128 @@
+# Plan 298 — Context Efficacy Proving Harness (v0.7.0)
+
+Source issue: #298. Ship vehicle: feature branch → PR → main → v0.7.0 release.
+
+## Goal
+
+Break the static-scan ceiling: stop scoring what artifacts *exist* and start proving
+what they *do*, with reproducible evidence, reported as a separate **Efficacy Score**
+(0–100) alongside the Proficiency Score. Turn the tool from a context *linter* into a
+context *proving harness*.
+
+## Decisions locked (via /plan-interview)
+
+| Decision | Choice |
+|----------|--------|
+| Execution model | `--prove` = resolve/validate only (no arbitrary exec). `--prove-exec` = run repo code in a hardened sandbox. Exec **hard-blocked on remote/GitHub-scanned repos**. Whole pass opt-in; default scan unchanged. |
+| Scoring | Report-only **Efficacy Score (0–100)** + per-artifact pass/fail. Does NOT change level or proficiency score. |
+| MVP provers | (1) Commands, (2) Hooks, (3) Token-efficiency / context budget (deterministic, no exec). |
+| Surfaces | CLI (`--prove`/`--prove-exec`), MCP `prove_efficacy` tool, CI gh-aw workflow (PR comment). |
+| Security | Threat model + executor hardening + required `harden-auditor` pass before merge. |
+| Deferred | Skills smoke prover; LLM behavior-change probe; efficacy gating L6+. |
+
+## Success Criteria
+
+Done when, on this repo and fixtures:
+1. `measure-ai-proficiency --prove` runs WITHOUT executing any repo-defined code, and reports:
+   - per documented command: resolves? (✓/✗) with the exact check command;
+   - per hook: wired? (✓/✗) with where it's declared;
+   - a **Context Budget**: always-on token estimate, % of a reference window, efficiency ratio;
+   - an aggregate **Efficacy Score (0–100)**.
+2. `measure-ai-proficiency --prove-exec` additionally executes commands/hooks in the sandbox and reports run outcomes; it **refuses to exec** for `--github-repo`/`--github-org` (prints why) and when `--prove-exec` is absent.
+3. Efficacy is rendered in all four reporters and serialized in JSON (`_score_to_dict`) and CSV; the level and proficiency score are byte-for-byte unchanged when `--prove` is off.
+4. MCP `prove_efficacy` tool returns the same structured result (resolve-only by default; exec arg honored but blocked for remote).
+5. CI gh-aw workflow runs the (resolve-only) pass on PRs and comments the efficacy result.
+6. Threat model documented; `harden-auditor` green on the executor; `pytest` green (new tests for each prover + the remote-exec block + the off-by-default invariant); ≥2 new eval cases.
+
+## Architecture
+
+New isolated module `measure_ai_proficiency/efficacy.py` (mirrors `signals.py`):
+
+```
+efficacy.py
+  @dataclass ArtifactCheck   { name, kind, status: pass|fail|skip, evidence, reproduce_cmd, detail }
+  @dataclass ProberResult    { prober, checks: List[ArtifactCheck], score, summary }
+  @dataclass ContextBudget   { always_on_tokens, files: Dict[path,tokens], window_tokens, pct_of_window, efficiency_ratio, method }
+  @dataclass EfficacyResult  { provers: Dict[str,ProberResult], context_budget, score, executed: bool, warnings }
+  class EfficacyAnalyzer(repo_path, score: RepoScore, execute: bool, is_remote: bool, config)
+      run() -> EfficacyResult        # runs the 3 provers; never execs if is_remote or not execute
+  # provers
+  _prove_commands(...)   # extract documented commands -> shutil.which / `<cmd> --help` (exec gated)
+  _prove_hooks(...)      # parse settings.json + .claude/hooks; exec synthetic event (exec gated)
+  _measure_context_budget(...)  # deterministic token estimate of always-on context
+  # sandbox
+  _run_sandboxed(cmd, stdin, cwd, timeout, env_allowlist) -> (rc, out, err, timed_out)
+```
+
+- **Tokenizer:** use `tiktoken` if importable, else a heuristic (`ceil(chars/4)`); record `method` in the output. No hard new dependency.
+- **Always-on set for the budget:** present `INSTRUCTION_FILES` (CLAUDE.md, AGENTS.md, copilot-instructions, .cursorrules, CODEX.md) + the cumulative skill **frontmatter metadata** (Layer-2, the part that's effectively always-routable). Reference window default `context_window_tokens = 200_000` (configurable).
+- **Score:** weighted blend of command-resolution rate, hook-wiring(/exec) rate, and a budget-efficiency factor; capped 0–100; report-only.
+
+## Integration points (precise)
+
+- `scanner.py`: add `efficacy: Optional["EfficacyResult"] = None` to `RepoScore`. Do **not** call efficacy from `scan()`. Add a thin `RepoScanner.prove(score, execute, is_remote)` that delegates to `EfficacyAnalyzer`. (`__init__.py` exports the new public types.)
+- `__main__.py` (argparse, ~L160): add `--prove`, `--prove-exec` (implies prove), `--context-window N`. After scoring each repo, if prove requested → run analyzer with `execute=args.prove_exec` and `is_remote=(github mode)`; attach `score.efficacy`. Exec is forced off for `--github-repo`/`--github-org`/`--org` with a printed notice.
+- `reporter.py`: render efficacy in `TerminalReporter`/`MarkdownReporter` (a "Context Efficacy (--prove)" section: per-artifact ✓/✗ + reproduce cmd, Context Budget, Efficacy Score), in `JsonReporter._score_to_dict` (an `efficacy` block — also consumed by MCP), and a couple of CSV columns (`efficacy_score`, `always_on_tokens`).
+- `mcp_server.py`: new `prove_efficacy` tool (list_tools + call_tool + handler). Resolve-only by default; optional `execute` arg honored only for the local cwd repo (never remote).
+- `repo_config.py`: add `context_window_tokens` (default 200000) + `command_allowlist` (safe default set) + `prove` skip hooks, parsed from `.ai-proficiency.yaml`.
+- `.github/workflows/efficacy.md` (+ compiled `.lock.yml` via `gh aw compile`): PR-triggered, runs `--prove` (resolve-only), comments the efficacy summary. (CI exec deferred.)
+- Docs: `docs/EFFICACY.md` (the harness + threat model), plus pointers from `README.md`, `docs/SIGNALS.md`, `CLAUDE.md`. Bump `__init__.py` + `pyproject.toml` → 0.7.0.
+
+## Threat Model (executor)
+
+`--prove-exec` runs repo-defined commands/hooks → treat repo input as untrusted.
+
+| Risk | Mitigation |
+|------|------------|
+| Arbitrary code exec on scan | Exec is opt-in (`--prove-exec`), **never** on remote/GitHub repos, never in default scan; prints what it will run. |
+| Destructive commands | Command **allowlist** (basenames); prefer `--help`/dry-run; deny shell metacharacters; no `shell=True`. |
+| Env/secret exfiltration | Scrubbed env (minimal PATH + explicit allowlist), no inherited tokens. |
+| Runaway / hang | Per-call timeout + output size cap + total-time budget. |
+| Network calls | Best-effort: scrub proxy vars; document that true network isolation needs a container (known limitation, called out in `log()`/docs). |
+| Path escape | Run with `cwd` set; resolve+contain any written paths (reuse the 0.6.0 traversal guard pattern). |
+
+A `harden-auditor` pass over `efficacy.py` must be green before merge.
+
+## Affected Files/Areas
+
+New: `efficacy.py`, `docs/EFFICACY.md`, `docs/plans/plan-298-...md`, `.github/workflows/efficacy.{md,lock.yml}`, `.evals/cases/EVAL-014+.md`, tests `tests/test_efficacy.py` (+ MCP/reporter test additions).
+Modified: `scanner.py` (RepoScore field + prove()), `__main__.py` (flags), `reporter.py` (4 renderers + JSON/CSV), `mcp_server.py` (tool), `repo_config.py` (config), `__init__.py`/`pyproject.toml` (0.7.0), `README.md`/`docs/SIGNALS.md`/`docs/MCP.md`/`CLAUDE.md`/`.evals/EVAL_INDEX.md`.
+
+## Risk Assessment
+
+- **Security (high):** mitigated by the threat model above + opt-in + remote-block + harden pass.
+- **False positives in command extraction (med):** conservative extractor (only fenced/backticked tokens that look like real CLIs; skip prose); mark uncertain as `skip`, not `fail`.
+- **Tokenizer accuracy (low):** heuristic is approximate; label the method and treat the budget as an estimate, not a verdict.
+- **Backward-compat (low):** efficacy is additive + opt-in; assert level/score unchanged when off.
+- **OneDrive git friction (op):** push via the established fast-/tmp-clone path.
+
+## Rejected Alternatives
+
+- *Execute by default* — too risky for a tool people run on arbitrary repos.
+- *Make efficacy modify/gate the score now* — deferred; ship the measurement first (earn complexity), gate in a later version once the signal is trusted.
+- *Container-based sandbox in MVP* — heavy/portability cost; revisit if exec scope grows.
+
+## Open Questions
+
+- [ ] Tokenizer: ship pure-heuristic only, or optional `tiktoken`? — Can proceed (default heuristic; tiktoken if present).
+- [ ] CI: resolve-only in 0.7.0, exec-in-CI later? — Can proceed (resolve-only).
+- [ ] Always-on budget: include skill frontmatter metadata or instruction files only? — Can proceed (instruction files + skill frontmatter; configurable).
+- [ ] Command allowlist default contents — Can proceed (start strict: build/test/lint tooling basenames; user-extendable via config).
+
+## Implementation Checklist
+
+- [ ] `efficacy.py`: dataclasses + `EfficacyAnalyzer` + sandbox runner (hardened).
+- [ ] Commands prover (resolve + gated exec).
+- [ ] Hooks prover (wiring + gated synthetic-event exec).
+- [ ] Context-budget prover (deterministic token estimate + efficiency ratio).
+- [ ] Wire `RepoScore.efficacy` + `RepoScanner.prove()`; keep `scan()` unchanged.
+- [ ] `__main__.py` flags (`--prove`, `--prove-exec`, `--context-window`) + remote-exec block.
+- [ ] Reporters (terminal/markdown/json/csv) + `_score_to_dict` efficacy block.
+- [ ] MCP `prove_efficacy` tool (+ test).
+- [ ] `repo_config.py` options + parsing.
+- [ ] CI gh-aw `efficacy.md` (+ compile) PR comment.
+- [ ] Tests: per-prover, remote-exec-blocked, off-by-default invariant, MCP, reporter.
+- [ ] Eval cases EVAL-014+ (efficacy module + remote-block guard).
+- [ ] Threat model doc `docs/EFFICACY.md` + harden-auditor pass.
+- [ ] Docs (README/SIGNALS/MCP/CLAUDE) + bump to 0.7.0.
+- [ ] Verify: `pytest` green; dogfood `--prove` on this repo; then branch → PR → release.

--- a/measure_ai_proficiency/__init__.py
+++ b/measure_ai_proficiency/__init__.py
@@ -17,7 +17,7 @@ Supports:
 - Tool-specific recommendations
 """
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 __author__ = "Peter Skoett"
 
 from .scanner import (
@@ -33,6 +33,13 @@ from .scanner import (
     StructuralQuality,
 )
 from .signals import SignalGroup, SIGNAL_GROUPS, LEVEL_GATE_REQUIREMENTS
+from .efficacy import (
+    EfficacyAnalyzer,
+    EfficacyResult,
+    ProberResult,
+    ArtifactCheck,
+    ContextBudget,
+)
 from .reporter import (
     TerminalReporter,
     JsonReporter,
@@ -63,6 +70,11 @@ __all__ = [
     "SignalGroup",
     "SIGNAL_GROUPS",
     "LEVEL_GATE_REQUIREMENTS",
+    "EfficacyAnalyzer",
+    "EfficacyResult",
+    "ProberResult",
+    "ArtifactCheck",
+    "ContextBudget",
     "TerminalReporter",
     "JsonReporter",
     "MarkdownReporter",

--- a/measure_ai_proficiency/__main__.py
+++ b/measure_ai_proficiency/__main__.py
@@ -199,11 +199,14 @@ GitHub CLI Requirements:
     is_remote = bool(args.github_repo or args.github_org)
     cw = args.context_window
     if args.prove_exec and is_remote:
+        # Hard error (not a silent downgrade) so automation can't gain false confidence
+        # that an exec pass ran. Execution is never permitted on remote/GitHub repos.
         print(
-            "Note: --prove-exec ignored for remote scans (execution is disabled for "
-            "GitHub-scanned repos); running resolve-only.",
+            "Error: --prove-exec is not permitted with --github-repo/--github-org "
+            "(execution is disabled for remote repos). Use --prove for a resolve-only pass.",
             file=sys.stderr,
         )
+        sys.exit(1)
 
     # Track temp directories for cleanup
     temp_dirs = []

--- a/measure_ai_proficiency/__main__.py
+++ b/measure_ai_proficiency/__main__.py
@@ -149,6 +149,30 @@ GitHub CLI Requirements:
     )
 
     parser.add_argument(
+        "--prove",
+        action="store_true",
+        help="Run the efficacy proving pass (RESOLVE-ONLY: checks commands resolve, hooks "
+             "are wired, and estimates the always-on context token budget). Reports a "
+             "report-only Efficacy Score; does not change the level/score. Runs no repo code.",
+    )
+
+    parser.add_argument(
+        "--prove-exec",
+        action="store_true",
+        help="Like --prove, but ALSO executes allowlisted documented commands (the `--help` "
+             "probe only) in a hardened sandbox. Hooks are always validate-only (never "
+             "executed). Local repos only; never runs for --github-repo/--github-org. "
+             "Repo code is untrusted input — use deliberately.",
+    )
+
+    parser.add_argument(
+        "--context-window",
+        type=int,
+        metavar="TOKENS",
+        help="Reference context-window size (tokens) for the budget prover (default: 200000)",
+    )
+
+    parser.add_argument(
         "--version",
         action="version",
         version=f"%(prog)s {__version__}",
@@ -170,6 +194,17 @@ GitHub CLI Requirements:
     # Verbose is now the default; use --quiet to suppress
     verbose = not args.quiet
 
+    # Efficacy proving (opt-in). Execution is never allowed on remote/GitHub repos.
+    prove = args.prove or args.prove_exec
+    is_remote = bool(args.github_repo or args.github_org)
+    cw = args.context_window
+    if args.prove_exec and is_remote:
+        print(
+            "Note: --prove-exec ignored for remote scans (execution is disabled for "
+            "GitHub-scanned repos); running resolve-only.",
+            file=sys.stderr,
+        )
+
     # Track temp directories for cleanup
     temp_dirs = []
 
@@ -183,6 +218,8 @@ GitHub CLI Requirements:
             temp_dirs.append(temp_dir)
             scanner = RepoScanner(str(temp_dir), verbose=verbose)
             scores = [scanner.scan()]
+            if prove:
+                scanner.prove(scores[0], execute=False, is_remote=True, context_window=cw)
             # Set repo name for display
             scores[0].repo_path = args.github_repo
 
@@ -199,6 +236,8 @@ GitHub CLI Requirements:
                 temp_dirs.append(temp_dir)
                 scanner = RepoScanner(str(temp_dir), verbose=verbose)
                 score = scanner.scan()
+                if prove:
+                    scanner.prove(score, execute=False, is_remote=True, context_window=cw)
                 # Set repo name for display
                 score.repo_path = repo_name
                 scores.append(score)
@@ -206,6 +245,10 @@ GitHub CLI Requirements:
         elif args.org:
             # Scan local org directory
             scores = scan_github_org(args.org, verbose=verbose)
+            if prove:
+                for s in scores:
+                    RepoScanner(str(s.repo_path), verbose=verbose).prove(
+                        s, execute=args.prove_exec, is_remote=False, context_window=cw)
 
         elif len(args.paths) == 1:
             # Single local repo
@@ -215,10 +258,16 @@ GitHub CLI Requirements:
                 sys.exit(1)
             scanner = RepoScanner(str(repo_path), verbose=verbose)
             scores = [scanner.scan()]
+            if prove:
+                scanner.prove(scores[0], execute=args.prove_exec, is_remote=False, context_window=cw)
 
         else:
             # Multiple local repos
             scores = scan_multiple_repos(args.paths, verbose=verbose)
+            if prove:
+                for s in scores:
+                    RepoScanner(str(s.repo_path), verbose=verbose).prove(
+                        s, execute=args.prove_exec, is_remote=False, context_window=cw)
 
         # Filter by minimum level if specified
         if args.min_level is not None:

--- a/measure_ai_proficiency/efficacy.py
+++ b/measure_ai_proficiency/efficacy.py
@@ -1,0 +1,585 @@
+"""
+Context efficacy proving harness (v0.7.0).
+
+Proves what a repository's AI artifacts actually DO, not just that they exist, and
+reports a separate, **report-only** Efficacy Score (0-100) plus per-artifact green/red
+evidence with a reproducing command. It never changes the Proficiency Score or level.
+
+SECURITY (see docs/EFFICACY.md for the full threat model):
+- The default pass (`execute=False`, i.e. CLI `--prove`) RESOLVES/VALIDATES only — it
+  runs no repo-defined code. It checks that documented commands resolve, that hooks are
+  wired, and estimates the always-on token budget.
+- Executing repo-defined commands/hooks requires explicit opt-in (`execute=True`, i.e.
+  CLI `--prove-exec`) and is HARD-BLOCKED for remote / GitHub-scanned repos.
+- Repo content is treated as untrusted input: execution uses an argv list (never via a
+  shell), a command allowlist, a scrubbed env, a timeout, and an output cap.
+- Hooks are NEVER executed (only validated for wiring + contained script existence);
+  only the commands prober runs, and only a fixed `<cmd> --help` probe (never the
+  documented arguments).
+"""
+
+import os
+import re
+import json
+import math
+import shutil
+import tempfile
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+# =============================================================================
+# Hardening constants
+# =============================================================================
+
+# Env vars passed through to sandboxed processes (everything else is dropped).
+# NOTE: HOME is intentionally EXCLUDED — it is replaced with a throwaway temp dir per
+# call so user credential files (~/.npmrc, ~/.pypirc, ~/.m2/settings.xml, ...) can never
+# be read by a probed tool.
+_SAFE_ENV_KEYS = ("PATH", "LANG", "LC_ALL", "LC_CTYPE", "TMPDIR", "SYSTEMROOT")
+
+# Default allowlist of command basenames eligible for the `<cmd> --help` probe under
+# --prove-exec. Resolution checks (`which`) are always safe and not gated by this.
+#
+# DELIBERATELY EXCLUDES general-purpose shells / code-eval runtimes (bash, sh, python,
+# node, deno, ruby, perl, ...): those accept arbitrary code via `-c`/`-e`, so allowing
+# them — even just for `--help` — would weaken the allowlist as a defense. Only build /
+# test / lint *nouns* that don't take an arbitrary code string are included. (Hooks are
+# never executed at all; see _prove_hooks.)
+DEFAULT_COMMAND_ALLOWLIST: frozenset = frozenset({
+    "make", "just", "npm", "pnpm", "yarn", "pytest", "go", "cargo", "ruff",
+    "black", "mypy", "flake8", "eslint", "prettier", "tox", "uv", "pip", "pip3",
+    "jest", "vitest", "tsc", "poetry", "gradle", "mvn", "dotnet", "rake",
+    "bundle", "rubocop", "golangci-lint", "pre-commit", "hatch", "nox",
+})
+
+_EXEC_TIMEOUT_SECONDS = 15      # per command/hook
+_OUTPUT_CAP_BYTES = 8_000       # captured stdout/stderr cap
+_DEFAULT_CONTEXT_WINDOW = 200_000
+
+# Hook lifecycle event names (Claude Code).
+_HOOK_EVENTS = (
+    "PreToolUse", "PostToolUse", "SessionStart", "Stop",
+    "SubagentStop", "UserPromptSubmit", "PreCompact", "Notification",
+)
+
+# Words that look command-like in backticks but are prose/builtins we skip to reduce
+# false positives in the commands prober.
+_COMMAND_STOPWORDS = frozenset({
+    "the", "a", "an", "and", "or", "if", "for", "in", "to", "of", "is", "are",
+    "this", "that", "true", "false", "null", "none", "todo", "note", "eg", "ie",
+})
+
+# Inline-code / fenced command extraction.
+_INLINE_CODE = re.compile(r"`([^`\n]{2,200})`")
+_FENCED_BLOCK = re.compile(r"```(?:bash|sh|shell|console|zsh)?\n(.*?)```", re.DOTALL)
+_CMD_FIRST_TOKEN = re.compile(r"^[a-z][a-z0-9_.-]{1,40}$")
+
+
+# =============================================================================
+# Result data structures
+# =============================================================================
+
+@dataclass
+class ArtifactCheck:
+    """One proven (or skipped) artifact."""
+
+    name: str
+    kind: str                      # "command" | "hook"
+    status: str                    # "pass" | "fail" | "skip"
+    evidence: str = ""
+    reproduce_cmd: str = ""
+    detail: str = ""
+
+
+@dataclass
+class ProberResult:
+    """Output of a single prober."""
+
+    prober: str                    # "commands" | "hooks"
+    checks: List[ArtifactCheck] = field(default_factory=list)
+    summary: str = ""
+
+    @property
+    def passed(self) -> int:
+        return sum(1 for c in self.checks if c.status == "pass")
+
+    @property
+    def total_scored(self) -> int:
+        """Checks that count toward the rate (pass + fail; skips excluded)."""
+        return sum(1 for c in self.checks if c.status in ("pass", "fail"))
+
+    @property
+    def rate(self) -> Optional[float]:
+        """Pass rate over scored checks, or None if nothing to prove."""
+        if self.total_scored == 0:
+            return None
+        return self.passed / self.total_scored
+
+
+@dataclass
+class ContextBudget:
+    """Always-on context token footprint (deterministic; no execution)."""
+
+    always_on_tokens: int = 0
+    files: Dict[str, int] = field(default_factory=dict)   # path -> tokens
+    skill_metadata_tokens: int = 0
+    window_tokens: int = _DEFAULT_CONTEXT_WINDOW
+    method: str = "heuristic"      # "tiktoken" | "heuristic"
+
+    @property
+    def pct_of_window(self) -> float:
+        if self.window_tokens <= 0:
+            return 0.0
+        return self.always_on_tokens / self.window_tokens * 100
+
+    @property
+    def efficiency_factor(self) -> float:
+        """0-1 efficiency: full credit under ~1.5% of the window, decaying to 0 by ~6%."""
+        pct = self.pct_of_window
+        if pct <= 1.5:
+            return 1.0
+        if pct >= 6.0:
+            return 0.0
+        return round(1.0 - (pct - 1.5) / 4.5, 3)
+
+
+@dataclass
+class EfficacyResult:
+    """Combined efficacy evidence + report-only score."""
+
+    provers: Dict[str, ProberResult] = field(default_factory=dict)
+    context_budget: Optional[ContextBudget] = None
+    executed: bool = False         # whether any repo code was actually run
+    warnings: List[str] = field(default_factory=list)
+
+    @property
+    def score(self) -> float:
+        """Report-only Efficacy Score (0-100): mean of available sub-scores.
+
+        Provers with nothing to prove are excluded (absence is the Proficiency
+        score's concern, not efficacy's).
+        """
+        parts: List[float] = []
+        for p in self.provers.values():
+            if p.rate is not None:
+                parts.append(p.rate)
+        if self.context_budget and self.context_budget.always_on_tokens > 0:
+            parts.append(self.context_budget.efficiency_factor)
+        if not parts:
+            return 0.0
+        return round(sum(parts) / len(parts) * 100, 1)
+
+    @property
+    def has_evidence(self) -> bool:
+        return any(p.checks for p in self.provers.values()) or bool(
+            self.context_budget and self.context_budget.always_on_tokens > 0
+        )
+
+
+# =============================================================================
+# Token estimation
+# =============================================================================
+
+def estimate_tokens(text: str) -> Tuple[int, str]:
+    """Estimate tokens. Uses tiktoken if importable, else a chars/4 heuristic."""
+    if not text:
+        return 0, "heuristic"
+    try:
+        import tiktoken  # optional dependency
+        enc = tiktoken.get_encoding("cl100k_base")
+        return len(enc.encode(text)), "tiktoken"
+    except Exception:
+        return math.ceil(len(text) / 4), "heuristic"
+
+
+# =============================================================================
+# Analyzer
+# =============================================================================
+
+class EfficacyAnalyzer:
+    """Runs the efficacy provers against a repository.
+
+    `score` is the RepoScore from a prior scan (duck-typed to avoid importing the
+    scanner module here). It is read-only.
+    """
+
+    def __init__(
+        self,
+        repo_path,
+        score=None,
+        execute: bool = False,
+        is_remote: bool = False,
+        config=None,
+        context_window: Optional[int] = None,
+    ):
+        self.repo_path = Path(repo_path)
+        self.score = score
+        # Execution is opt-in AND never permitted on remote/GitHub-scanned repos.
+        self.is_remote = is_remote
+        self.execute = bool(execute) and not is_remote
+        self.config = config
+        self.context_window = (
+            context_window
+            or getattr(config, "context_window_tokens", None)
+            or _DEFAULT_CONTEXT_WINDOW
+        )
+        # The allowlist is a SECURITY control, so it must never be WIDENED by untrusted
+        # repo content. A repo-supplied list (from .ai-proficiency.yaml) can only NARROW
+        # the built-in default via intersection — never add commands.
+        repo_allow = getattr(config, "command_allowlist", None)
+        if repo_allow:
+            self.allowlist = frozenset(repo_allow) & DEFAULT_COMMAND_ALLOWLIST
+        else:
+            self.allowlist = DEFAULT_COMMAND_ALLOWLIST
+
+    # ----- public -----
+
+    def run(self) -> EfficacyResult:
+        result = EfficacyResult(executed=self.execute)
+        if self.is_remote:
+            result.warnings.append(
+                "Execution is disabled for remote/GitHub-scanned repos; resolve-only results shown."
+            )
+        elif not self.execute:
+            result.warnings.append(
+                "Resolve-only pass (no repo code executed). Use --prove-exec to probe "
+                "documented commands with `--help`. (Hooks are always validate-only.)"
+            )
+        else:
+            result.warnings.append(
+                "Executing allowlisted documented commands with `--help` only. "
+                "Hooks are validate-only (never executed)."
+            )
+        result.provers["commands"] = self._prove_commands()
+        result.provers["hooks"] = self._prove_hooks()
+        # Context budget is a measurement (no pass/fail checks), so it is reported as a
+        # separate `context_budget` field rather than a ProberResult in `provers`. It
+        # still contributes its efficiency_factor to the overall Efficacy Score.
+        result.context_budget = self._measure_context_budget()
+        return result
+
+    # ----- helpers -----
+
+    def _within_repo(self, path: Path) -> bool:
+        """True if path resolves to a location strictly inside the repo (symlink-safe)."""
+        try:
+            repo_root = self.repo_path.resolve()
+            resolved = path.resolve()
+            return resolved == repo_root or repo_root in resolved.parents
+        except (OSError, ValueError, RuntimeError):
+            return False
+
+    def _read(self, rel: str) -> Optional[str]:
+        path = self.repo_path / rel
+        try:
+            # Containment guards against a symlink in the repo pointing outside it.
+            if path.is_file() and self._within_repo(path) and path.stat().st_size <= 1_000_000:
+                return path.read_text(encoding="utf-8", errors="ignore")
+        except (OSError, PermissionError):
+            return None
+        return None
+
+    def _instruction_files(self) -> List[str]:
+        # Lazy import avoids a module-load cycle with scanner.
+        from .scanner import INSTRUCTION_FILES
+        present = []
+        for name in INSTRUCTION_FILES:
+            if (self.repo_path / name).is_file():
+                present.append(name)
+        return present
+
+    def _run_sandboxed(self, argv: List[str], stdin: Optional[str] = None) -> dict:
+        """Run argv in a hardened subprocess. Returns a result dict.
+
+        Runs from an argv list only (never via a shell). Allowlisted basename only.
+        Scrubbed env. Timeout + output cap.
+        """
+        base = os.path.basename(argv[0]) if argv else ""
+        if base not in self.allowlist:
+            return {"blocked": True, "rc": None, "out": "", "err": f"{base} not in allowlist", "timed_out": False}
+
+        # Always run the PATH-resolved binary for the allowlisted basename — never an
+        # arbitrary (possibly absolute) caller-supplied path. Closes the basename-checked-
+        # but-argv0-executed inconsistency.
+        resolved = shutil.which(base)
+        if not resolved:
+            return {"blocked": False, "rc": None, "out": "", "err": f"{base} not found", "timed_out": False}
+
+        env = {k: os.environ[k] for k in _SAFE_ENV_KEYS if k in os.environ}
+        # Best-effort hostility reduction (true network isolation needs a container).
+        env["GIT_TERMINAL_PROMPT"] = "0"
+        env["PIP_NO_INPUT"] = "1"
+        env["CI"] = "1"
+        # Throwaway HOME so user credential files are never read/leaked by the probe.
+        home = tempfile.mkdtemp(prefix="maip-prove-home-")
+        env["HOME"] = home
+        env["NPM_CONFIG_USERCONFIG"] = os.path.join(home, ".npmrc")
+        env["PIP_CONFIG_FILE"] = os.path.join(home, "pip.conf")
+        env["GRADLE_USER_HOME"] = os.path.join(home, ".gradle")
+        run_argv = [resolved] + list(argv[1:])
+        try:
+            proc = subprocess.run(
+                run_argv,
+                cwd=str(self.repo_path),
+                env=env,
+                input=stdin,
+                capture_output=True,
+                text=True,
+                timeout=_EXEC_TIMEOUT_SECONDS,
+                check=False,
+            )
+            return {
+                "blocked": False,
+                "rc": proc.returncode,
+                "out": (proc.stdout or "")[:_OUTPUT_CAP_BYTES],
+                "err": (proc.stderr or "")[:_OUTPUT_CAP_BYTES],
+                "timed_out": False,
+            }
+        except subprocess.TimeoutExpired:
+            return {"blocked": False, "rc": None, "out": "", "err": "timeout", "timed_out": True}
+        except (OSError, ValueError) as e:
+            return {"blocked": False, "rc": None, "out": "", "err": str(e), "timed_out": False}
+        finally:
+            shutil.rmtree(home, ignore_errors=True)
+
+    # ----- provers -----
+
+    def _extract_commands(self) -> List[str]:
+        """Conservatively extract documented CLI command basenames from instruction files."""
+        candidates: List[str] = []
+        seen = set()
+        for rel in self._instruction_files():
+            content = self._read(rel)
+            if not content:
+                continue
+            spans: List[str] = list(_INLINE_CODE.findall(content))
+            for block in _FENCED_BLOCK.findall(content):
+                for line in block.splitlines():
+                    line = line.strip()
+                    if line and not line.startswith("#"):
+                        spans.append(line)
+            for span in spans:
+                span = span.strip().lstrip("$ ").strip()
+                if not span:
+                    continue
+                first = span.split()[0] if span.split() else ""
+                first = first.strip("`'\"")
+                # Must look like a CLI basename (no slashes/metachars) — this is the
+                # real filter; bare prose words are rejected by the regex + stopwords +
+                # the has-args/allowlist check below.
+                if not _CMD_FIRST_TOKEN.match(first):
+                    continue
+                if first in _COMMAND_STOPWORDS:
+                    continue
+                # Only count a token as a command if it takes args (looks like usage)
+                # or is in the allowlist of known tools.
+                has_args = len(span.split()) > 1
+                if not has_args and first not in self.allowlist:
+                    continue
+                if first not in seen:
+                    seen.add(first)
+                    candidates.append(first)
+        return candidates
+
+    def _prove_commands(self) -> ProberResult:
+        result = ProberResult(prober="commands")
+        commands = self._extract_commands()
+        for cmd in commands:
+            resolved = shutil.which(cmd) is not None
+            if not resolved:
+                result.checks.append(ArtifactCheck(
+                    name=cmd, kind="command", status="fail",
+                    evidence="not found on PATH",
+                    reproduce_cmd=f"command -v {cmd}",
+                    detail="documented command does not resolve",
+                ))
+                continue
+            if not self.execute:
+                result.checks.append(ArtifactCheck(
+                    name=cmd, kind="command", status="pass",
+                    evidence=f"resolves to {shutil.which(cmd)}",
+                    reproduce_cmd=f"command -v {cmd}",
+                ))
+                continue
+            # Execute a benign probe (--help) under the sandbox.
+            res = self._run_sandboxed([cmd, "--help"])
+            if res["blocked"]:
+                result.checks.append(ArtifactCheck(
+                    name=cmd, kind="command", status="skip",
+                    evidence="resolves; exec skipped (not in allowlist)",
+                    reproduce_cmd=f"command -v {cmd}",
+                ))
+            elif res["timed_out"]:
+                result.checks.append(ArtifactCheck(
+                    name=cmd, kind="command", status="fail",
+                    evidence="`--help` timed out", reproduce_cmd=f"{cmd} --help",
+                ))
+            else:
+                # Help text commonly exits 0/1/2; treat "ran without crashing" as pass.
+                ok = res["rc"] is not None
+                result.checks.append(ArtifactCheck(
+                    name=cmd, kind="command", status="pass" if ok else "fail",
+                    evidence=f"`--help` exit={res['rc']}", reproduce_cmd=f"{cmd} --help",
+                ))
+        if commands:
+            result.summary = f"{result.passed}/{result.total_scored} documented commands work"
+        else:
+            result.summary = "no documented CLI commands found"
+        return result
+
+    def _hook_commands(self) -> List[Tuple[str, str]]:
+        """Return (event, command) pairs from the COMMITTED settings.json only.
+
+        settings.local.json is intentionally skipped: it is gitignored/local and may
+        contain user-specific hook commands with credentials/paths we should not capture
+        into the (potentially PR-posted) efficacy report. Efficacy proves committed context.
+        """
+        pairs: List[Tuple[str, str]] = []
+        for rel in (".claude/settings.json",):
+            content = self._read(rel)
+            if not content:
+                continue
+            try:
+                data = json.loads(content)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            hooks = data.get("hooks") if isinstance(data, dict) else None
+            if not isinstance(hooks, dict):
+                continue
+            for event, entries in hooks.items():
+                if not isinstance(entries, list):
+                    continue
+                for entry in entries:
+                    inner = entry.get("hooks", []) if isinstance(entry, dict) else []
+                    for h in inner if isinstance(inner, list) else []:
+                        if isinstance(h, dict) and h.get("command"):
+                            pairs.append((event, str(h["command"])))
+        return pairs
+
+    def _prove_hooks(self) -> ProberResult:
+        result = ProberResult(prober="hooks")
+        pairs = self._hook_commands()
+
+        # Also note hook scripts present on disk (wired implicitly by convention).
+        hooks_dir = self.repo_path / ".claude" / "hooks"
+        script_files: List[Path] = []
+        if hooks_dir.is_dir():
+            try:
+                script_files = [f for f in hooks_dir.iterdir() if f.is_file()]
+            except (OSError, PermissionError):
+                pass
+
+        # SECURITY: hooks are NEVER executed (their command strings are arbitrary
+        # untrusted shell). We only validate that they are wired and that any
+        # referenced repo-local script actually exists. This holds even under
+        # --prove-exec — running hook command strings safely needs a container,
+        # which is out of scope (see docs/EFFICACY.md).
+        for event, command in pairs:
+            argv = command.split()
+            first = os.path.basename(argv[0]) if argv else ""
+            # Sanitize untrusted values from repo settings.json before embedding them in
+            # report strings (they could carry shell metacharacters/newlines): the event
+            # name against the known-events allowlist, and the command basename against
+            # the CLI-token charset.
+            safe_event = event if event in _HOOK_EVENTS else repr(event)
+            safe_first = first if _CMD_FIRST_TOKEN.match(first) else "<cmd>"
+            referenced = self._resolve_referenced_script(argv)
+            if referenced is not None and not referenced.exists():
+                result.checks.append(ArtifactCheck(
+                    name=f"{safe_event}:{safe_first}", kind="hook", status="fail",
+                    evidence=f"hook script missing: {referenced}",
+                    reproduce_cmd=f"test -f {referenced}",
+                    detail="hook wired but its script is absent",
+                ))
+                continue
+            result.checks.append(ArtifactCheck(
+                name=f"{safe_event}:{safe_first}", kind="hook", status="pass",
+                evidence="wired in settings (validate-only; hooks are not executed)",
+                reproduce_cmd=f"jq '.hooks[\"{safe_event}\"]' .claude/settings.json",
+            ))
+
+        for f in script_files:
+            if f.suffix.lower() == ".md":
+                continue
+            rel = str(f.relative_to(self.repo_path))
+            # Informational only ("skip" so it doesn't inflate the pass rate): a script's
+            # mere presence doesn't prove it's wired or works.
+            result.checks.append(ArtifactCheck(
+                name=rel, kind="hook", status="skip",
+                evidence="hook script present (not independently graded)",
+                reproduce_cmd=f"test -f {rel}",
+            ))
+
+        if result.checks:
+            result.summary = f"{result.passed}/{result.total_scored} hooks wired/valid (validate-only)"
+        else:
+            result.summary = "no hooks configured"
+        return result
+
+    def _resolve_referenced_script(self, argv: List[str]) -> Optional[Path]:
+        """If a hook command points at a repo-local script file, return its path."""
+        for tok in argv:
+            if "/" in tok and (tok.endswith(".sh") or tok.endswith(".py") or ".claude/hooks" in tok):
+                # Strip only a leading "./" prefix (NOT lstrip('./'), which would also
+                # eat the leading dot of ".claude/...").
+                rel = tok[2:] if tok.startswith("./") else tok
+                candidate = (self.repo_path / rel).resolve()
+                # Contain strictly INSIDE the repo dir (a path equal to the repo root is
+                # never a valid script file, so it is not accepted).
+                try:
+                    repo_root = self.repo_path.resolve()
+                    if repo_root in candidate.parents:
+                        return candidate
+                except (OSError, ValueError):
+                    return None
+        return None
+
+    def _measure_context_budget(self) -> ContextBudget:
+        budget = ContextBudget(window_tokens=int(self.context_window))
+        method = "heuristic"
+        total = 0
+        for rel in self._instruction_files():
+            content = self._read(rel)
+            if not content:
+                continue
+            toks, m = estimate_tokens(content)
+            method = m
+            budget.files[rel] = toks
+            total += toks
+
+        # Always-routable skill metadata (Layer-2 frontmatter is effectively always loaded).
+        meta_tokens = 0
+        for pattern in (".claude/skills/*/SKILL.md", ".github/skills/*/SKILL.md", "skills/*/SKILL.md"):
+            try:
+                for skill in self.repo_path.glob(pattern):
+                    # glob follows symlinks; skip any SKILL.md that resolves outside the
+                    # repo so a malicious symlink can't pull in /etc/passwd, ~/.ssh, etc.
+                    if not (skill.is_file() and self._within_repo(skill)):
+                        continue
+                    content = skill.read_text(encoding="utf-8", errors="ignore")
+                    fm = _frontmatter(content)
+                    if fm:
+                        toks, m = estimate_tokens(fm)
+                        method = m
+                        meta_tokens += toks
+            except (OSError, PermissionError):
+                pass
+
+        budget.skill_metadata_tokens = meta_tokens
+        budget.always_on_tokens = total + meta_tokens
+        budget.method = method
+        return budget
+
+
+def _frontmatter(content: str) -> str:
+    """Extract the YAML frontmatter block (between leading --- fences), else ''."""
+    if not content.lstrip().startswith("---"):
+        return ""
+    stripped = content.lstrip()
+    end = stripped.find("\n---", 3)
+    if end == -1:
+        return ""
+    return stripped[: end + 4]

--- a/measure_ai_proficiency/efficacy.py
+++ b/measure_ai_proficiency/efficacy.py
@@ -425,7 +425,8 @@ class EfficacyAnalyzer:
                     evidence=f"`--help` exit={res['rc']}", reproduce_cmd=f"{cmd} --help",
                 ))
         if commands:
-            result.summary = f"{result.passed}/{result.total_scored} documented commands work"
+            verb = "respond to --help" if self.execute else "resolve on PATH"
+            result.summary = f"{result.passed}/{result.total_scored} documented commands {verb}"
         else:
             result.summary = "no documented CLI commands found"
         return result
@@ -488,10 +489,16 @@ class EfficacyAnalyzer:
             safe_first = first if _CMD_FIRST_TOKEN.match(first) else "<cmd>"
             referenced = self._resolve_referenced_script(argv)
             if referenced is not None and not referenced.exists():
+                # Report a repo-relative path so no runner filesystem layout leaks into
+                # the (potentially PR-posted) report.
+                try:
+                    rel_ref = referenced.relative_to(self.repo_path.resolve())
+                except (ValueError, OSError):
+                    rel_ref = referenced.name
                 result.checks.append(ArtifactCheck(
                     name=f"{safe_event}:{safe_first}", kind="hook", status="fail",
-                    evidence=f"hook script missing: {referenced}",
-                    reproduce_cmd=f"test -f {referenced}",
+                    evidence=f"hook script missing: {rel_ref}",
+                    reproduce_cmd=f"test -f {rel_ref}",
                     detail="hook wired but its script is absent",
                 ))
                 continue
@@ -522,6 +529,10 @@ class EfficacyAnalyzer:
     def _resolve_referenced_script(self, argv: List[str]) -> Optional[Path]:
         """If a hook command points at a repo-local script file, return its path."""
         for tok in argv:
+            # Only repo-local script paths are validatable. Reject absolute paths
+            # outright (an absolute operand would also override repo_path in `/`).
+            if os.path.isabs(tok):
+                continue
             if "/" in tok and (tok.endswith(".sh") or tok.endswith(".py") or ".claude/hooks" in tok):
                 # Strip only a leading "./" prefix (NOT lstrip('./'), which would also
                 # eat the leading dot of ".claude/...").

--- a/measure_ai_proficiency/efficacy.py
+++ b/measure_ai_proficiency/efficacy.py
@@ -35,10 +35,12 @@ from typing import Dict, List, Optional, Tuple
 # =============================================================================
 
 # Env vars passed through to sandboxed processes (everything else is dropped).
-# NOTE: HOME is intentionally EXCLUDED — it is replaced with a throwaway temp dir per
-# call so user credential files (~/.npmrc, ~/.pypirc, ~/.m2/settings.xml, ...) can never
-# be read by a probed tool.
-_SAFE_ENV_KEYS = ("PATH", "LANG", "LC_ALL", "LC_CTYPE", "TMPDIR", "SYSTEMROOT")
+# Intentionally EXCLUDES HOME (replaced with a throwaway temp dir per call so user
+# credential files ~/.npmrc, ~/.pypirc, ~/.m2/settings.xml, ... can't be read), TMPDIR
+# (operator-redirectable; the throwaway HOME gives writable space), and ALL credential/
+# token vars (e.g. GITHUB_TOKEN, GH_TOKEN, AWS_*, NPM_TOKEN, XDG_CONFIG_HOME, CARGO_HOME,
+# GOPATH). Add new keys here only after confirming they cannot carry secrets.
+_SAFE_ENV_KEYS = ("PATH", "LANG", "LC_ALL", "LC_CTYPE", "SYSTEMROOT")
 
 # Default allowlist of command basenames eligible for the `<cmd> --help` probe under
 # --prove-exec. Resolution checks (`which`) are always safe and not gated by this.
@@ -469,7 +471,9 @@ class EfficacyAnalyzer:
         script_files: List[Path] = []
         if hooks_dir.is_dir():
             try:
-                script_files = [f for f in hooks_dir.iterdir() if f.is_file()]
+                script_files = [
+                    f for f in hooks_dir.iterdir() if f.is_file() and self._within_repo(f)
+                ]
             except (OSError, PermissionError):
                 pass
 
@@ -485,7 +489,7 @@ class EfficacyAnalyzer:
             # report strings (they could carry shell metacharacters/newlines): the event
             # name against the known-events allowlist, and the command basename against
             # the CLI-token charset.
-            safe_event = event if event in _HOOK_EVENTS else repr(event)
+            safe_event = event if event in _HOOK_EVENTS else "<custom-event>"
             safe_first = first if _CMD_FIRST_TOKEN.match(first) else "<cmd>"
             referenced = self._resolve_referenced_script(argv)
             if referenced is not None and not referenced.exists():

--- a/measure_ai_proficiency/mcp_server.py
+++ b/measure_ai_proficiency/mcp_server.py
@@ -228,6 +228,15 @@ async def list_tools() -> list[Tool]:
                 "required": [],
             },
         ),
+        Tool(
+            name="prove_efficacy",
+            description="Prove what the current repo's AI artifacts actually DO (report-only Efficacy Score + per-artifact evidence): documented commands resolve, hooks are wired, and the always-on context token budget. RESOLVE-ONLY (runs no repo code) — executing commands is CLI-only (`measure-ai-proficiency --prove-exec`), never via this tool.",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        ),
     ]
 
 
@@ -270,6 +279,8 @@ async def call_tool(name: str, arguments: Any) -> list[TextContent]:
             return await curricula_alignment_handler()
         elif name == "cheapest_primitive_decision_tree_report":
             return await cheapest_primitive_decision_tree_report_handler()
+        elif name == "prove_efficacy":
+            return await prove_efficacy_handler()
         else:
             raise ValueError(f"Unknown tool: {name}")
     except Exception as e:
@@ -818,6 +829,61 @@ async def cheapest_primitive_decision_tree_report_handler() -> list[TextContent]
         },
         "progressive_disclosure_reference": "https://docs.claude.com/en/docs/claude-code/skills",
     }
+    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+
+async def prove_efficacy_handler() -> list[TextContent]:
+    """Run the report-only, RESOLVE-ONLY efficacy proving pass on the current repo.
+
+    Execution of repo-defined commands is intentionally NOT available via MCP (no
+    human-in-the-loop confirmation here); use the CLI `--prove-exec` for that.
+    """
+    repo_path = get_current_repo()
+    scanner = RepoScanner(repo_path)
+
+    def _run():
+        score = scanner.scan()
+        scanner.prove(score, execute=False, is_remote=False)
+        return score
+
+    score = await asyncio.to_thread(_run)
+    eff = score.efficacy
+    if not eff:
+        return [TextContent(type="text", text=json.dumps(
+            {"error": "Efficacy was not computed for this repository"}, indent=2))]
+
+    result: Dict[str, Any] = {
+        "repo_name": score.repo_name,
+        "efficacy_score": eff.score,
+        "executed": eff.executed,
+        "warnings": eff.warnings,
+        "provers": {
+            name: {
+                "summary": p.summary,
+                "checks": [
+                    {
+                        "name": c.name,
+                        "status": c.status,
+                        "evidence": c.evidence,
+                        "reproduce_cmd": c.reproduce_cmd,
+                    }
+                    for c in p.checks
+                ],
+            }
+            for name, p in eff.provers.items()
+        },
+        "note": "Report-only: does not change the Proficiency Score or level. These are "
+                "static/sandboxed proxies, not a guarantee of full runtime efficacy.",
+    }
+    if eff.context_budget:
+        b = eff.context_budget
+        result["context_budget"] = {
+            "always_on_tokens": b.always_on_tokens,
+            "pct_of_window": round(b.pct_of_window, 2),
+            "window_tokens": b.window_tokens,
+            "efficiency_factor": b.efficiency_factor,
+            "method": b.method,
+        }
     return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
 

--- a/measure_ai_proficiency/mcp_server.py
+++ b/measure_ai_proficiency/mcp_server.py
@@ -843,6 +843,9 @@ async def prove_efficacy_handler() -> list[TextContent]:
 
     def _run():
         score = scanner.scan()
+        # is_remote=False is safe: this handler only ever operates on the local working
+        # directory (get_current_repo() == Path.cwd()), never a GitHub-fetched temp dir.
+        # execute=False also means no repo code runs regardless.
         scanner.prove(score, execute=False, is_remote=False)
         return score
 

--- a/measure_ai_proficiency/repo_config.py
+++ b/measure_ai_proficiency/repo_config.py
@@ -49,6 +49,10 @@ class RepoConfig:
     word_threshold_bloat: int = 1500  # Words above which an always-on file is "bloated"
     git_timeout: int = 5  # Git command timeout in seconds
 
+    # Efficacy proving (--prove / --prove-exec)
+    context_window_tokens: int = 200_000  # Reference window for the context-budget prover
+    command_allowlist: Optional[List[str]] = None  # Exec allowlist; can only NARROW the built-in default (intersection), never widen it
+
     # Whether config was loaded from file
     from_file: bool = False
 
@@ -213,6 +217,10 @@ def load_repo_config(repo_path: Path) -> RepoConfig:
                     config.word_threshold_full = int(quality["word_threshold_full"])
                 if "word_threshold_bloat" in quality:
                     config.word_threshold_bloat = int(quality["word_threshold_bloat"])
+                if "context_window_tokens" in quality:
+                    config.context_window_tokens = int(quality["context_window_tokens"])
+                if "command_allowlist" in quality and isinstance(quality["command_allowlist"], list):
+                    config.command_allowlist = [str(c) for c in quality["command_allowlist"]]
                 if "git_timeout" in quality:
                     config.git_timeout = int(quality["git_timeout"])
 

--- a/measure_ai_proficiency/reporter.py
+++ b/measure_ai_proficiency/reporter.py
@@ -430,6 +430,35 @@ class TerminalReporter:
                 print(f"    {_color(f'Signal Bonus: +{sig.bonus_points:.1f}', Colors.CYAN)}", file=output)
             print(file=output)
 
+        # Context efficacy (--prove)
+        if score.efficacy and score.efficacy.has_evidence:
+            eff = score.efficacy
+            mode = "executed" if eff.executed else "resolve-only"
+            print(_color(f"  Context Efficacy ({mode}):", Colors.BOLD), file=output)
+            print(file=output)
+            for name, p in eff.provers.items():
+                if not p.checks:
+                    continue
+                print(f"    {name}: {p.summary}", file=output)
+                for c in p.checks[:8]:
+                    icon = "✓" if c.status == "pass" else ("✗" if c.status == "fail" else "○")
+                    color = Colors.GREEN if c.status == "pass" else (Colors.RED if c.status == "fail" else Colors.DIM)
+                    repro = _color(f"  [{c.reproduce_cmd}]", Colors.DIM) if c.reproduce_cmd else ""
+                    print(f"      {_color(icon, color)} {c.name} — {c.evidence}{repro}", file=output)
+            b = eff.context_budget
+            if b and b.always_on_tokens > 0:
+                print(file=output)
+                print(
+                    f"    Context budget: ~{b.always_on_tokens} always-on tokens "
+                    f"({b.pct_of_window:.2f}% of {b.window_tokens}, {b.method})",
+                    file=output,
+                )
+            print(file=output)
+            print(f"    {_color(f'Efficacy Score: {eff.score}/100', Colors.CYAN)}", file=output)
+            for w in eff.warnings:
+                print(f"    {_color(w, Colors.DIM)}", file=output)
+            print(file=output)
+
         # Recommendations
         if score.recommendations:
             print(_color("  Recommendations:", Colors.BOLD), file=output)
@@ -747,6 +776,46 @@ class JsonReporter:
                     "plugins_present": sq.plugins_present,
                 }
 
+        # Add efficacy proving results if present (--prove; report-only)
+        if score.efficacy:
+            eff = score.efficacy
+            result["efficacy"] = {
+                "score": eff.score,
+                "executed": eff.executed,
+                "warnings": eff.warnings,
+                "provers": {
+                    name: {
+                        "summary": p.summary,
+                        "passed": p.passed,
+                        "total_scored": p.total_scored,
+                        "rate": round(p.rate, 3) if p.rate is not None else None,
+                        "checks": [
+                            {
+                                "name": c.name,
+                                "kind": c.kind,
+                                "status": c.status,
+                                "evidence": c.evidence,
+                                "reproduce_cmd": c.reproduce_cmd,
+                                "detail": c.detail,
+                            }
+                            for c in p.checks
+                        ],
+                    }
+                    for name, p in eff.provers.items()
+                },
+            }
+            if eff.context_budget:
+                b = eff.context_budget
+                result["efficacy"]["context_budget"] = {
+                    "always_on_tokens": b.always_on_tokens,
+                    "skill_metadata_tokens": b.skill_metadata_tokens,
+                    "files": b.files,
+                    "window_tokens": b.window_tokens,
+                    "pct_of_window": round(b.pct_of_window, 2),
+                    "efficiency_factor": b.efficiency_factor,
+                    "method": b.method,
+                }
+
         return result
 
     def report_single(self, score: RepoScore, output: TextIO = sys.stdout) -> None:
@@ -1025,6 +1094,32 @@ class MarkdownReporter:
                     print(f"| L{lvl} | {gate} | {missing} |", file=output)
             print(file=output)
 
+        # Context efficacy section (--prove)
+        if score.efficacy and score.efficacy.has_evidence:
+            eff = score.efficacy
+            mode = "executed" if eff.executed else "resolve-only"
+            print(f"## Context Efficacy ({mode})", file=output)
+            print(file=output)
+            print(f"- **Efficacy Score:** {eff.score}/100", file=output)
+            b = eff.context_budget
+            if b and b.always_on_tokens > 0:
+                print(
+                    f"- **Context budget:** ~{b.always_on_tokens} always-on tokens "
+                    f"({b.pct_of_window:.2f}% of {b.window_tokens}, {b.method})",
+                    file=output,
+                )
+            print(file=output)
+            print("| Prover | Artifact | Status | Evidence |", file=output)
+            print("|--------|----------|--------|----------|", file=output)
+            for name, p in eff.provers.items():
+                for c in p.checks:
+                    mark = ":white_check_mark:" if c.status == "pass" else (":x:" if c.status == "fail" else ":o:")
+                    print(f"| {name} | `{c.name}` | {mark} {c.status} | {c.evidence} |", file=output)
+            print(file=output)
+            for w in eff.warnings:
+                print(f"> {w}", file=output)
+            print(file=output)
+
         if score.recommendations:
             print("## Recommendations", file=output)
             print(file=output)
@@ -1128,6 +1223,7 @@ class CsvReporter:
         # with the level_N_coverage columns kept last.
         header = "repo_name,repo_path,overall_level,overall_score,bonus_points,avg_quality,ref_count,resolved_count,validation_penalty,has_stale_files,has_templates,warning_count,ci_agents,handoffs_valid,outcomes_valid"
         header += ",signal_bonus,structural_score,matched_signal_count,l6_gate,l7_gate,l8_gate"
+        header += ",efficacy_score,always_on_tokens,efficacy_executed"
         for i in range(1, 9):
             header += f",level_{i}_coverage"
         print(header, file=output)
@@ -1188,6 +1284,17 @@ class CsvReporter:
                 l7_gate = sig.gates.get(7, False)
                 l8_gate = sig.gates.get(8, False)
 
+            # Efficacy data (--prove); blank when not run
+            efficacy_score = ""
+            always_on_tokens = ""
+            efficacy_executed = ""
+            if score.efficacy and score.efficacy.has_evidence:
+                eff = score.efficacy
+                efficacy_score = f"{eff.score:.1f}"
+                efficacy_executed = str(eff.executed)
+                if eff.context_budget:
+                    always_on_tokens = str(eff.context_budget.always_on_tokens)
+
             line = (
                 f'"{score.repo_name}","{score.repo_path}",{score.overall_level},'
                 f'{score.overall_score:.2f},{bonus:.2f},{avg_quality:.2f},'
@@ -1195,7 +1302,8 @@ class CsvReporter:
                 f'{has_stale},{has_templates},{warning_count},'
                 f'{ci_agents},{handoffs_valid},{outcomes_valid},'
                 f'{signal_bonus:.2f},{structural_score:.2f},{matched_signal_count},'
-                f'{l6_gate},{l7_gate},{l8_gate}'
+                f'{l6_gate},{l7_gate},{l8_gate},'
+                f'{efficacy_score},{always_on_tokens},{efficacy_executed}'
             )
             for cov in coverages:
                 line += f",{cov:.2f}"

--- a/measure_ai_proficiency/scanner.py
+++ b/measure_ai_proficiency/scanner.py
@@ -12,7 +12,10 @@ import subprocess
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .efficacy import EfficacyResult
 
 from .config import LEVELS, CORE_AI_FILES, LevelConfig, filter_patterns_for_tools
 from .signals import (
@@ -568,6 +571,7 @@ class RepoScore:
     default_level: Optional[int] = None  # Level with default thresholds (when custom are used)
     validation: Optional[ValidationResult] = None  # Content validation results (Improvements 2-4)
     signals: Optional["HarnessSignals"] = None  # 2026 context-engineering signals (gates L6-8)
+    efficacy: Optional["EfficacyResult"] = None  # Runtime efficacy proving results (--prove; report-only)
 
     @property
     def has_any_ai_files(self) -> bool:
@@ -682,6 +686,37 @@ class RepoScanner:
         score.recommendations = self._generate_recommendations(score)
 
         return score
+
+    def prove(
+        self,
+        score: RepoScore,
+        execute: bool = False,
+        is_remote: bool = False,
+        context_window: Optional[int] = None,
+    ) -> "EfficacyResult":
+        """Run the report-only efficacy proving pass and attach it to the score.
+
+        Opt-in (CLI --prove / --prove-exec). Does NOT change the level or score.
+        Execution is hard-blocked when is_remote=True. Lazy import avoids a cycle.
+        """
+        from .efficacy import EfficacyAnalyzer
+
+        # Ensure repo config is loaded so .ai-proficiency.yaml overrides (allowlist
+        # narrowing, context window) apply even when prove() is called on a fresh
+        # scanner that never ran scan() (e.g. the --org / multi-repo paths).
+        if self.config is None:
+            self.config = load_repo_config(self.repo_path)
+
+        result = EfficacyAnalyzer(
+            self.repo_path,
+            score=score,
+            execute=execute,
+            is_remote=is_remote,
+            config=self.config,
+            context_window=context_window,
+        ).run()
+        score.efficacy = result
+        return result
 
     def _scan_level(self, level_num: int, config: LevelConfig) -> LevelScore:
         """Scan for files matching a specific level's patterns."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "measure-ai-proficiency"
-version = "0.6.0"
+version = "0.7.0"
 description = "Measure AI coding proficiency based on context engineering artifacts"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_efficacy.py
+++ b/tests/test_efficacy.py
@@ -1,0 +1,139 @@
+"""
+Tests for the context efficacy proving harness (--prove).
+
+Security-critical invariants covered:
+- resolve-only by default (no repo code executed)
+- execution hard-blocked on remote/GitHub-scanned repos
+- efficacy is off by default (a normal scan computes none)
+- report-only (never changes the level or proficiency score)
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from measure_ai_proficiency import RepoScanner
+
+
+def _make_repo(root: Path, *, missing_hook: bool = True) -> None:
+    """Fixture: documented commands + wired hooks (one present, one missing) + a skill."""
+    (root / "CLAUDE.md").write_text(
+        "# Project\n## Commands\n"
+        "Run `python3 --version` for the interpreter. Build with `make build`.\n"
+        "`definitely-not-a-real-cmd-xyz --frobnicate` is documented but not installed.\n"
+        + "x" * 100
+    )
+    claude = root / ".claude"
+    (claude / "hooks").mkdir(parents=True)
+    (claude / "hooks" / "format.sh").write_text("echo formatted\n")
+    hooks_json = (
+        '{"hooks":{'
+        '"PreToolUse":[{"matcher":"Write","hooks":[{"type":"command","command":"bash .claude/hooks/format.sh"}]}]'
+    )
+    if missing_hook:
+        hooks_json += ',"Stop":[{"hooks":[{"type":"command","command":"bash .claude/hooks/missing.sh"}]}]'
+    hooks_json += "}}\n"
+    (claude / "settings.json").write_text(hooks_json)
+    skill = claude / "skills" / "foo"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: foo\ndescription: does foo when needed\n---\n# Foo\n")
+
+
+class TestEfficacyDefaults:
+    def test_efficacy_off_by_default(self):
+        """A normal scan must NOT compute efficacy."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_repo(Path(tmp))
+            score = RepoScanner(tmp).scan()
+            assert score.efficacy is None
+
+    def test_prove_does_not_change_level_or_score(self):
+        """Proving is report-only: level and proficiency score are unchanged."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_repo(Path(tmp))
+            sc = RepoScanner(tmp)
+            score = sc.scan()
+            level_before, score_before = score.overall_level, score.overall_score
+            sc.prove(score, execute=False, is_remote=False)
+            assert score.overall_level == level_before
+            assert score.overall_score == score_before
+
+
+class TestEfficacyProvers:
+    def test_resolve_only_executes_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_repo(Path(tmp))
+            sc = RepoScanner(tmp)
+            score = sc.scan()
+            eff = sc.prove(score, execute=False, is_remote=False)
+            assert eff.executed is False
+            assert any("Resolve-only" in w for w in eff.warnings)
+
+    def test_command_resolution(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_repo(Path(tmp))
+            sc = RepoScanner(tmp)
+            eff = sc.prove(sc.scan(), execute=False, is_remote=False)
+            cmds = {c.name: c.status for c in eff.provers["commands"].checks}
+            assert cmds.get("python3") == "pass"
+            assert cmds.get("definitely-not-a-real-cmd-xyz") == "fail"
+
+    def test_hook_wiring_and_missing_script(self):
+        """The present hook script must NOT be flagged missing; the missing one must fail."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_repo(Path(tmp))
+            sc = RepoScanner(tmp)
+            eff = sc.prove(sc.scan(), execute=False, is_remote=False)
+            checks = eff.provers["hooks"].checks
+            # The PreToolUse hook references .claude/hooks/format.sh which exists.
+            pre = [c for c in checks if c.name.startswith("PreToolUse")]
+            assert pre and all(c.status != "fail" for c in pre), "present hook script falsely failed"
+            # The Stop hook references a missing script.
+            stop = [c for c in checks if c.name.startswith("Stop")]
+            assert stop and any(c.status == "fail" for c in stop)
+
+    def test_context_budget(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_repo(Path(tmp))
+            sc = RepoScanner(tmp)
+            eff = sc.prove(sc.scan(), execute=False, is_remote=False)
+            b = eff.context_budget
+            assert b is not None
+            assert b.always_on_tokens > 0
+            assert "CLAUDE.md" in b.files
+            assert 0.0 <= b.efficiency_factor <= 1.0
+            assert 0.0 <= b.pct_of_window
+
+    def test_efficacy_score_in_range(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_repo(Path(tmp))
+            sc = RepoScanner(tmp)
+            eff = sc.prove(sc.scan(), execute=False, is_remote=False)
+            assert 0.0 <= eff.score <= 100.0
+
+
+class TestEfficacySecurity:
+    def test_remote_blocks_execution(self):
+        """Execution must be hard-blocked when is_remote=True even with execute=True."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_repo(Path(tmp))
+            sc = RepoScanner(tmp)
+            eff = sc.prove(sc.scan(), execute=True, is_remote=True)
+            assert eff.executed is False
+            assert any("remote" in w.lower() or "disabled" in w.lower() for w in eff.warnings)
+
+    def test_exec_does_not_run_interpreters_or_hooks(self):
+        """Under --prove-exec, shells/interpreters are NOT allowlisted (not executed),
+        and hooks are never executed (validate-only)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_repo(Path(tmp))
+            sc = RepoScanner(tmp)
+            eff = sc.prove(sc.scan(), execute=True, is_remote=False)
+            assert eff.executed is True
+            cmds = {c.name: c for c in eff.provers["commands"].checks}
+            # python3 resolves but is intentionally NOT allowlisted -> never executed
+            assert "exit=" not in cmds["python3"].evidence
+            # hooks are validate-only even under exec (never executed)
+            for c in eff.provers["hooks"].checks:
+                assert "exit=" not in c.evidence and "ran" not in c.evidence

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -27,6 +27,7 @@ from measure_ai_proficiency.mcp_server import (
     get_dynamic_workflow_recommendations_handler,
     curricula_alignment_handler,
     cheapest_primitive_decision_tree_report_handler,
+    prove_efficacy_handler,
 )
 from measure_ai_proficiency.scanner import RepoScanner, RepoScore
 
@@ -553,3 +554,19 @@ class TestSignalTools:
         data = json.loads(result[0].text)
         assert data["maintenance_hygiene_detected"] is False
         assert len(data["recommendations"]) >= 1
+
+    @pytest.mark.asyncio
+    async def test_prove_efficacy_resolve_only(self, tmp_path, monkeypatch):
+        """prove_efficacy defaults to resolve-only (no repo code executed)."""
+        monkeypatch.setattr(
+            "measure_ai_proficiency.mcp_server.get_current_repo", lambda: tmp_path
+        )
+        (tmp_path / "CLAUDE.md").write_text(
+            "# Project\nRun `python3 --version`.\n" + "x" * 100
+        )
+        result = await prove_efficacy_handler()
+        data = json.loads(result[0].text)
+        assert data["executed"] is False
+        assert "efficacy_score" in data
+        assert "provers" in data
+        assert "context_budget" in data


### PR DESCRIPTION
Closes #298.

## What

Turns the scanner from a context **linter** into a context **proving harness**: a new `--prove` pass that produces a **report-only Efficacy Score (0–100)** proving what a repo's AI artifacts actually *do*, with reproducible per-artifact evidence. Never changes the Proficiency Score or level. Full design + threat model in `docs/EFFICACY.md`.

## Provers (MVP)
- **Commands** — documented CLI commands resolve (`which`); under `--prove-exec`, only a fixed `<cmd> --help` probe of the PATH-resolved, allowlisted binary runs (never the documented args).
- **Hooks** — **validate-only** (wiring + contained script existence). Hooks are **never executed** (their command strings are arbitrary untrusted shell).
- **Context budget** (deterministic, no exec) — always-on token footprint (instruction files + skill frontmatter), % of a reference window, efficiency factor. Quantifies the conciseness/bloat work.

## Security (passed a `harden-auditor` gate — 3 audit rounds, all findings fixed)
- `--prove` runs no repo code; `--prove-exec` is opt-in, **local-only**, and **hard-blocked on remote/GitHub scans**; default scan unchanged.
- argv lists only (never a shell); allowlist of build/test/lint *nouns* (no shells/interpreters); repo config can only **narrow** the allowlist (intersection), never widen it.
- `HOME` replaced with a throwaway temp dir per probe (no credential-file reads); symlink containment on reads; per-call timeout + output cap; untrusted report fields sanitized; `settings.local.json` skipped.
- MCP `prove_efficacy` is **resolve-only** (exec is CLI-only — no MCP path to execute repo code).

## Surfaces
CLI (`--prove` / `--prove-exec` / `--context-window`) in all 4 reporters + JSON/CSV; MCP `prove_efficacy` tool; a PR CI workflow (`.github/workflows/efficacy.yml`, resolve-only) that comments the efficacy result.

## Verification
- `pytest` → **152 passed** (new `tests/test_efficacy.py` covers defaults/provers/security: resolve-only, remote-exec-blocked, off-by-default, report-only).
- Evals **EVAL-014/015/016** guard the engine + two security invariants (remote-exec block; no `shell=True`).
- Adversarial harden + spec audit (parallel auditors) — **harden verdict: pass**.

## Deferred (named)
Skills smoke prover; LLM behavior-change probe; efficacy gating L6+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
